### PR TITLE
Add notification profile polling

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,13 @@ GitHub → Cloudflare Tunnel → webhook server (FastAPI :8080)
                              MCP server (stdio) ← Claude (Lin/Lay)
 ```
 
+Recommended polling flow:
+
+1. Poll `get_pending_status` every 60 seconds.
+2. If `pending_count > 0`, call `list_pending_events`.
+3. Only call `get_event` for the specific event IDs that need full payloads.
+4. Call `mark_processed` after handling them.
+
 ## Setup
 
 ### 1. Install dependencies
@@ -23,7 +30,7 @@ pip install -r requirements.txt
 ### 2. Start webhook receiver
 
 ```bash
-WEBHOOK_SECRET=your_secret python main.py webhook --port 8080
+WEBHOOK_SECRET=your_secret python main.py webhook --port 8080 --event-profile notifications
 ```
 
 ### 3. Set up Cloudflare Tunnel
@@ -41,7 +48,18 @@ cloudflared tunnel run
 - Payload URL: `https://webhook.yourdomain.com/webhook`
 - Content type: `application/json`
 - Secret: same value as `WEBHOOK_SECRET`
-- Events: Pull request reviews, Issue comments, Pull requests
+- Recommended event profile: choose these events to stay close to GitHub Notifications
+  - Issues
+  - Issue comments
+  - Pull requests
+  - Pull request reviews
+  - Pull request review comments
+  - Check runs
+  - Workflow runs
+  - Discussions
+  - Discussion comments
+
+If your webhook is temporarily set to `Send me everything`, start the receiver with `--event-profile notifications` and it will ignore noisy events such as `workflow_job` or `check_suite`.
 
 ### 5. Configure MCP server
 
@@ -62,8 +80,22 @@ Add to your Claude MCP config:
 
 | Tool | Description |
 |------|-------------|
+| `get_pending_status` | Lightweight pending count + type summary for polling |
+| `list_pending_events` | Lightweight metadata for pending events |
+| `get_event` | Full payload for a single event ID |
 | `get_webhook_events` | Get pending (unprocessed) webhook events |
 | `mark_processed` | Mark an event as processed |
+
+`get_webhook_events` is still available, but it returns raw webhook payloads and is much heavier than the status → summary → detail flow above.
+
+## Event Profiles
+
+The webhook receiver supports two profiles:
+
+- `all`: store every incoming webhook event
+- `notifications`: only store events that are close to GitHub Notifications, such as issue / PR activity, review activity, and completed CI results
+
+Use `notifications` for low-noise polling.
 
 ## Related
 

--- a/main.py
+++ b/main.py
@@ -3,7 +3,7 @@
 github-webhook-mcp — GitHub webhook receiver + MCP server
 
 Usage:
-  python main.py webhook [--port 8080] [--secret $WEBHOOK_SECRET]
+  python main.py webhook [--port 8080] [--secret $WEBHOOK_SECRET] [--event-profile all|notifications]
   python main.py mcp
 """
 import argparse
@@ -13,6 +13,7 @@ import hmac
 import json
 import os
 import uuid
+from collections import Counter
 
 from dotenv import load_dotenv
 load_dotenv()
@@ -21,17 +22,54 @@ from pathlib import Path
 from typing import Any
 
 DATA_FILE = Path(__file__).parent / "events.json"
+PRIMARY_ENCODING = "utf-8"
+LEGACY_ENCODINGS = ("utf-8-sig", "cp932", "shift_jis")
+NOTIFICATION_EVENT_ACTIONS = {
+    "issues": {"assigned", "closed", "opened", "reopened", "unassigned"},
+    "issue_comment": {"created"},
+    "pull_request": {
+        "assigned",
+        "closed",
+        "converted_to_draft",
+        "opened",
+        "ready_for_review",
+        "reopened",
+        "review_requested",
+        "review_request_removed",
+        "synchronize",
+        "unassigned",
+    },
+    "pull_request_review": {"dismissed", "submitted"},
+    "pull_request_review_comment": {"created"},
+    "check_run": {"completed"},
+    "workflow_run": {"completed"},
+    "discussion": {"answered", "closed", "created", "reopened"},
+    "discussion_comment": {"created"},
+}
 
 
 # ── Event Store ───────────────────────────────────────────────────────────────
 
 def _load() -> list[dict]:
     if DATA_FILE.exists():
-        return json.loads(DATA_FILE.read_text())
+        raw = DATA_FILE.read_bytes()
+        for encoding in (PRIMARY_ENCODING, *LEGACY_ENCODINGS):
+            try:
+                text = raw.decode(encoding)
+                events = json.loads(text)
+                if encoding != PRIMARY_ENCODING:
+                    _save(events)
+                return events
+            except (UnicodeDecodeError, json.JSONDecodeError):
+                continue
+        raise ValueError(f"Unable to decode event store: {DATA_FILE}")
     return []
 
 def _save(events: list[dict]) -> None:
-    DATA_FILE.write_text(json.dumps(events, ensure_ascii=False, indent=2))
+    DATA_FILE.write_text(
+        json.dumps(events, ensure_ascii=False, indent=2),
+        encoding=PRIMARY_ENCODING,
+    )
 
 def add_event(event_type: str, payload: dict) -> dict:
     events = _load()
@@ -49,6 +87,83 @@ def add_event(event_type: str, payload: dict) -> dict:
 def get_pending() -> list[dict]:
     return [e for e in _load() if not e["processed"]]
 
+def _normalize_event_profile(profile: str) -> str:
+    normalized = (profile or "all").strip().lower()
+    if normalized not in {"all", "notifications"}:
+        raise ValueError(f"Unknown event profile: {profile}")
+    return normalized
+
+def should_store_event(event_type: str, payload: dict, profile: str) -> bool:
+    normalized = _normalize_event_profile(profile)
+    if normalized == "all":
+        return True
+    allowed_actions = NOTIFICATION_EVENT_ACTIONS.get(event_type)
+    if not allowed_actions:
+        return False
+    action = payload.get("action")
+    return action in allowed_actions
+
+def _event_number(payload: dict) -> int | str | None:
+    return (
+        payload.get("number")
+        or (payload.get("issue") or {}).get("number")
+        or (payload.get("pull_request") or {}).get("number")
+    )
+
+def _event_title(payload: dict) -> str | None:
+    return (
+        (payload.get("issue") or {}).get("title")
+        or (payload.get("pull_request") or {}).get("title")
+        or (payload.get("discussion") or {}).get("title")
+        or (payload.get("check_run") or {}).get("name")
+        or (payload.get("workflow_run") or {}).get("name")
+        or (payload.get("workflow_job") or {}).get("name")
+    )
+
+def _event_url(payload: dict) -> str | None:
+    return (
+        (payload.get("issue") or {}).get("html_url")
+        or (payload.get("pull_request") or {}).get("html_url")
+        or (payload.get("discussion") or {}).get("html_url")
+        or (payload.get("check_run") or {}).get("html_url")
+        or (payload.get("workflow_run") or {}).get("html_url")
+    )
+
+def summarize_event(event: dict) -> dict:
+    payload = event.get("payload", {})
+    return {
+        "id": event["id"],
+        "type": event["type"],
+        "received_at": event["received_at"],
+        "processed": event["processed"],
+        "action": payload.get("action"),
+        "repo": (payload.get("repository") or {}).get("full_name"),
+        "sender": (payload.get("sender") or {}).get("login"),
+        "number": _event_number(payload),
+        "title": _event_title(payload),
+        "url": _event_url(payload),
+    }
+
+def get_pending_status() -> dict:
+    pending = get_pending()
+    return {
+        "pending_count": len(pending),
+        "latest_received_at": pending[-1]["received_at"] if pending else None,
+        "types": dict(Counter(event["type"] for event in pending)),
+    }
+
+def get_pending_summaries(limit: int = 20) -> list[dict]:
+    pending = get_pending()
+    if limit > 0:
+        pending = pending[-limit:]
+    return [summarize_event(event) for event in pending]
+
+def get_event(event_id: str) -> dict | None:
+    for event in _load():
+        if event["id"] == event_id:
+            return event
+    return None
+
 def mark_done(event_id: str) -> bool:
     events = _load()
     for e in events:
@@ -61,11 +176,12 @@ def mark_done(event_id: str) -> bool:
 
 # ── Webhook Server (FastAPI) ──────────────────────────────────────────────────
 
-def run_webhook(port: int, secret: str) -> None:
+def run_webhook(port: int, secret: str, event_profile: str) -> None:
     from fastapi import FastAPI, Header, HTTPException, Request
     import uvicorn
 
     app = FastAPI(title="github-webhook-mcp")
+    normalized_profile = _normalize_event_profile(event_profile)
 
     def _verify(body: bytes, sig: str) -> bool:
         if not secret:
@@ -89,6 +205,8 @@ def run_webhook(port: int, secret: str) -> None:
         if not _verify(body, x_hub_signature_256):
             raise HTTPException(status_code=401, detail="Invalid signature")
         payload = json.loads(body)
+        if not should_store_event(x_github_event, payload, normalized_profile):
+            return {"ignored": True, "type": x_github_event, "profile": normalized_profile}
         event = add_event(x_github_event, payload)
         return {"id": event["id"], "type": x_github_event}
 
@@ -108,10 +226,52 @@ async def run_mcp() -> None:
     async def list_tools() -> list[types.Tool]:
         return [
             types.Tool(
+                name="get_pending_status",
+                description=(
+                    "Get a lightweight snapshot of pending GitHub webhook events. "
+                    "Use this for periodic polling before requesting details."
+                ),
+                inputSchema={"type": "object", "properties": {}, "required": []},
+            ),
+            types.Tool(
+                name="list_pending_events",
+                description=(
+                    "List lightweight summaries for pending GitHub webhook events. "
+                    "Returns metadata only, without full payloads."
+                ),
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "limit": {
+                            "type": "integer",
+                            "description": "Maximum number of pending events to return",
+                            "minimum": 1,
+                            "maximum": 100,
+                            "default": 20,
+                        }
+                    },
+                    "required": [],
+                },
+            ),
+            types.Tool(
+                name="get_event",
+                description="Get the full payload for a single webhook event by ID.",
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "event_id": {
+                            "type": "string",
+                            "description": "The event ID to retrieve",
+                        }
+                    },
+                    "required": ["event_id"],
+                },
+            ),
+            types.Tool(
                 name="get_webhook_events",
                 description=(
-                    "Get pending (unprocessed) GitHub webhook events. "
-                    "Returns list of events with id, type, payload, received_at."
+                    "Get pending (unprocessed) GitHub webhook events with full payloads. "
+                    "Prefer get_pending_status or list_pending_events for polling."
                 ),
                 inputSchema={"type": "object", "properties": {}, "required": []},
             ),
@@ -135,6 +295,41 @@ async def run_mcp() -> None:
     async def call_tool(
         name: str, arguments: dict[str, Any]
     ) -> list[types.TextContent]:
+        if name == "get_pending_status":
+            status = get_pending_status()
+            return [
+                types.TextContent(
+                    type="text",
+                    text=json.dumps(status, ensure_ascii=False, indent=2),
+                )
+            ]
+        if name == "list_pending_events":
+            limit = arguments.get("limit", 20)
+            if not isinstance(limit, int):
+                raise ValueError("limit must be an integer")
+            summaries = get_pending_summaries(limit=limit)
+            return [
+                types.TextContent(
+                    type="text",
+                    text=json.dumps(summaries, ensure_ascii=False, indent=2),
+                )
+            ]
+        if name == "get_event":
+            event_id = arguments.get("event_id", "")
+            event = get_event(event_id)
+            if event is None:
+                return [
+                    types.TextContent(
+                        type="text",
+                        text=json.dumps({"error": "not_found", "event_id": event_id}),
+                    )
+                ]
+            return [
+                types.TextContent(
+                    type="text",
+                    text=json.dumps(event, ensure_ascii=False, indent=2),
+                )
+            ]
         if name == "get_webhook_events":
             events = get_pending()
             return [
@@ -171,12 +366,17 @@ if __name__ == "__main__":
     wp = sub.add_parser("webhook", help="Start webhook receiver (HTTP server)")
     wp.add_argument("--port", type=int, default=8080)
     wp.add_argument("--secret", default=os.environ.get("WEBHOOK_SECRET", ""))
+    wp.add_argument(
+        "--event-profile",
+        default=os.environ.get("WEBHOOK_EVENT_PROFILE", "all"),
+        choices=["all", "notifications"],
+    )
 
     sub.add_parser("mcp", help="Start MCP server (stdio transport)")
 
     args = parser.parse_args()
 
     if args.mode == "webhook":
-        run_webhook(port=args.port, secret=args.secret)
+        run_webhook(port=args.port, secret=args.secret, event_profile=args.event_profile)
     elif args.mode == "mcp":
         asyncio.run(run_mcp())

--- a/test_main.py
+++ b/test_main.py
@@ -1,0 +1,144 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+import main
+
+
+class EventStoreEncodingTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.original_data_file = main.DATA_FILE
+        main.DATA_FILE = Path(self.temp_dir.name) / "events.json"
+
+    def tearDown(self) -> None:
+        main.DATA_FILE = self.original_data_file
+        self.temp_dir.cleanup()
+
+    def test_save_uses_utf8(self) -> None:
+        event = {"id": "1", "type": "issue_comment", "payload": {"body": "日本語"}, "processed": False}
+
+        main._save([event])
+
+        raw = main.DATA_FILE.read_bytes()
+        self.assertIn("日本語".encode("utf-8"), raw)
+        self.assertEqual(json.loads(raw.decode("utf-8")), [event])
+
+    def test_load_reads_legacy_cp932_and_rewrites_utf8(self) -> None:
+        event = {"id": "1", "type": "issue_comment", "payload": {"body": "日本語"}, "processed": False}
+        legacy_text = json.dumps([event], ensure_ascii=False, indent=2)
+        main.DATA_FILE.write_bytes(legacy_text.encode("cp932"))
+
+        loaded = main._load()
+
+        self.assertEqual(loaded, [event])
+        self.assertEqual(json.loads(main.DATA_FILE.read_text(encoding="utf-8")), [event])
+
+
+class EventSummaryTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.original_data_file = main.DATA_FILE
+        main.DATA_FILE = Path(self.temp_dir.name) / "events.json"
+
+    def tearDown(self) -> None:
+        main.DATA_FILE = self.original_data_file
+        self.temp_dir.cleanup()
+
+    def test_pending_status_and_summaries_are_lightweight(self) -> None:
+        main.add_event(
+            "issues",
+            {
+                "action": "opened",
+                "repository": {"full_name": "Liplus-Project/liplus-language"},
+                "sender": {"login": "smileygames"},
+                "issue": {
+                    "number": 624,
+                    "title": "test",
+                    "html_url": "https://github.com/Liplus-Project/liplus-language/issues/624",
+                },
+            },
+        )
+        main.add_event(
+            "workflow_run",
+            {
+                "action": "completed",
+                "repository": {"full_name": "Liplus-Project/liplus-language"},
+                "sender": {"login": "github-actions"},
+                "workflow_run": {"name": "Governance CI", "html_url": "https://example.invalid/run"},
+            },
+        )
+
+        status = main.get_pending_status()
+        summaries = main.get_pending_summaries(limit=10)
+
+        self.assertEqual(status["pending_count"], 2)
+        self.assertEqual(status["types"], {"issues": 1, "workflow_run": 1})
+        self.assertEqual(len(summaries), 2)
+        self.assertEqual(summaries[0]["number"], 624)
+        self.assertEqual(summaries[0]["title"], "test")
+        self.assertEqual(summaries[1]["title"], "Governance CI")
+        self.assertNotIn("payload", summaries[0])
+
+    def test_get_event_returns_full_payload(self) -> None:
+        event = main.add_event(
+            "issues",
+            {
+                "action": "opened",
+                "repository": {"full_name": "Liplus-Project/liplus-language"},
+                "issue": {"number": 624, "title": "test"},
+            },
+        )
+
+        stored = main.get_event(event["id"])
+
+        self.assertIsNotNone(stored)
+        self.assertEqual(stored["payload"]["issue"]["number"], 624)
+
+
+class EventProfileTests(unittest.TestCase):
+    def test_notifications_profile_keeps_issue_and_ci_events(self) -> None:
+        self.assertTrue(
+            main.should_store_event(
+                "issues",
+                {"action": "opened"},
+                "notifications",
+            )
+        )
+        self.assertTrue(
+            main.should_store_event(
+                "workflow_run",
+                {"action": "completed"},
+                "notifications",
+            )
+        )
+
+    def test_notifications_profile_drops_non_notification_events(self) -> None:
+        self.assertFalse(
+            main.should_store_event(
+                "workflow_job",
+                {"action": "completed"},
+                "notifications",
+            )
+        )
+        self.assertFalse(
+            main.should_store_event(
+                "issue_comment",
+                {"action": "edited"},
+                "notifications",
+            )
+        )
+
+    def test_all_profile_keeps_everything(self) -> None:
+        self.assertTrue(
+            main.should_store_event(
+                "workflow_job",
+                {"action": "completed"},
+                "all",
+            )
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Refs #7
軽量ポーリング用に status -> summary -> detail のツール面を追加した。
notifications 相当の webhook プロファイルと README / テスト更新を含み、常駐運用時のノイズ削減を狙っている。
