### PR TITLE
fix(mcp-server): MCPB manifest validation and npm publish 0.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,44 @@ If your webhook is temporarily set to `Send me everything`, start the receiver w
 
 ### 6. Configure MCP server
 
-Add to your Claude MCP config:
+#### Option A: Claude Desktop — Desktop Extension (.mcpb)
+
+Download `mcp-server.mcpb` from [Releases](https://github.com/Liplus-Project/github-webhook-mcp/releases), then:
+
+1. Open Claude Desktop → **Settings** → **Extensions** → **Advanced settings** → **Install Extension...**
+2. Select the `.mcpb` file
+3. Enter the path to your `events.json` when prompted
+
+#### Option B: Claude Desktop / Claude Code — npx
+
+Add to your Claude MCP config (`claude_desktop_config.json` or project settings):
+
+```json
+{
+  "mcpServers": {
+    "github-webhook-mcp": {
+      "command": "npx",
+      "args": ["github-webhook-mcp"],
+      "env": {
+        "EVENTS_JSON_PATH": "/path/to/events.json"
+      }
+    }
+  }
+}
+```
+
+#### Option C: Codex — config.toml
+
+```toml
+[mcp.github-webhook-mcp]
+command = "npx"
+args = ["github-webhook-mcp"]
+
+[mcp.github-webhook-mcp.env]
+EVENTS_JSON_PATH = "/path/to/events.json"
+```
+
+#### Option D: Python (legacy)
 
 ```json
 {

--- a/mcp-server/manifest.json
+++ b/mcp-server/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": "0.3",
   "name": "github-webhook-mcp",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Browse pending GitHub webhook events. Pairs with a webhook receiver that writes events.json.",
   "author": {
     "name": "Liplus Project"
@@ -12,21 +12,22 @@
     "entry_point": "server/index.js",
     "mcp_config": {
       "command": "node",
-      "args": ["${__dirname}/server/index.js"],
+      "args": [
+        "${__dirname}/server/index.js"
+      ],
       "env": {
         "EVENTS_JSON_PATH": "${user_config.events_json_path}"
       }
     }
   },
-  "user_config": [
-    {
-      "id": "events_json_path",
-      "name": "Events JSON Path",
+  "user_config": {
+    "events_json_path": {
       "description": "Absolute path to the events.json file written by the webhook receiver.",
       "type": "string",
-      "required": true
+      "required": true,
+      "title": "Events JSON Path"
     }
-  ],
+  },
   "tools": [
     {
       "name": "get_pending_status",
@@ -50,6 +51,10 @@
     }
   ],
   "compatibility": {
-    "platforms": ["windows", "macos", "linux"]
+    "platforms": [
+      "win32",
+      "darwin",
+      "linux"
+    ]
   }
 }

--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "github-webhook-mcp",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "github-webhook-mcp",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,10 +1,10 @@
 {
   "name": "github-webhook-mcp",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "MCP server for browsing GitHub webhook events",
   "type": "module",
   "bin": {
-    "github-webhook-mcp": "./server/index.js"
+    "github-webhook-mcp": "server/index.js"
   },
   "main": "./server/index.js",
   "files": [
@@ -35,6 +35,6 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/Liplus-Project/github-webhook-mcp.git"
+    "url": "git+https://github.com/Liplus-Project/github-webhook-mcp.git"
   }
 }


### PR DESCRIPTION
Refs #21
manifest.json の MCPB バリデーションエラー修正、npm 0.2.1 publish、README にインストール手順追加（.mcpb / npx / Codex）。