### PR TITLE
fix(ci): update GitHub actions for Node 24 readiness

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -8,15 +8,15 @@ jobs:
   build-mcpb:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "24"
       - run: npm ci
         working-directory: mcp-server
       - run: npx mcpb pack
         working-directory: mcp-server
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: mcpb
           path: mcp-server/*.mcpb
@@ -27,8 +27,8 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
+      - uses: actions/checkout@v6
+      - uses: actions/download-artifact@v8
         with:
           name: mcpb
           path: dist/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
       - run: pip install -r requirements.txt


### PR DESCRIPTION
Refs #41
GitHub-hosted runner で出ている Node 20 deprecation warning に追従するため、CI/CD workflow の action major を更新した。
CD の build Node も 24 へ上げ、warning の主因だった actions 群を Node 24-ready 構成へ寄せている。