### PR TITLE
Add get_webhook_events tool to Worker McpAgent

### DIFF
--- a/worker/src/agent.ts
+++ b/worker/src/agent.ts
@@ -64,6 +64,20 @@ export class WebhookMcpAgent extends McpAgent<Env> {
     );
 
     this.server.tool(
+      "get_webhook_events",
+      "Get pending (unprocessed) GitHub webhook events with full payloads",
+      { limit: z.number().min(1).max(100).default(20).optional() },
+      async ({ limit }) => {
+        const l = limit ?? 20;
+        const res = await this.getStore().fetch(
+          new Request(`https://store/webhook-events?limit=${l}`),
+        );
+        const data = await res.json();
+        return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }] };
+      },
+    );
+
+    this.server.tool(
       "mark_processed",
       "Mark a webhook event as processed",
       { event_id: z.string() },

--- a/worker/src/store.ts
+++ b/worker/src/store.ts
@@ -146,6 +146,26 @@ export class WebhookStore extends DurableObject {
       return Response.json(summaries);
     }
 
+    // ── get_webhook_events (full payloads) ──
+    if (url.pathname === "/webhook-events") {
+      const limit = Number(url.searchParams.get("limit") || "20");
+      const rows = this.ctx.storage.sql.exec(
+        `SELECT * FROM events WHERE processed = 0 ORDER BY received_at DESC LIMIT ?`,
+        limit,
+      ).toArray();
+
+      const events: WebhookEvent[] = rows.map((row) => ({
+        id: row.id as string,
+        type: row.type as string,
+        received_at: row.received_at as string,
+        processed: (row.processed as number) === 1,
+        trigger_status: row.trigger_status as string | null,
+        last_triggered_at: row.last_triggered_at as string | null,
+        payload: JSON.parse(row.payload as string),
+      }));
+      return Response.json(events);
+    }
+
     // ── get_event ──
     if (url.pathname === "/event") {
       const eventId = url.searchParams.get("id");


### PR DESCRIPTION
Refs #54
WebhookStore DO に /webhook-events エンドポイントを追加。
McpAgent に get_webhook_events ツール（full payload 返却）を実装。