### PR TITLE
Add CI gate job for branch protection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,3 +16,16 @@ jobs:
           node-version: "22"
       - run: node --check mcp-server/server/index.js
       - run: cd worker && npm ci && npx wrangler deploy --dry-run --outdir dist
+
+  # Gate job: single Required status check for branch protection.
+  # Add new jobs to `needs` when CI grows. No Settings change needed.
+  CI:
+    if: always()
+    needs: [test]
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          if [[ "${{ needs.test.result }}" != "success" ]]; then
+            echo "CI failed: test=${{ needs.test.result }}"
+            exit 1
+          fi


### PR DESCRIPTION
Refs #68

gate パターン: 全 CI job の結果を集約する `CI` job を追加。
branch protection の Required check は `CI` 一つで済み、job 追加時に Settings を変更する必要がない。

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>