### PR TITLE
feat(cd): automate npm publish on tag push with version sync and prerelease support

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -39,3 +39,28 @@ jobs:
           gh release create "${{ github.ref_name }}" dist/*.mcpb \
             --title "${{ github.ref_name }}" \
             --generate-notes
+
+  npm-publish:
+    runs-on: ubuntu-latest
+    needs: release
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
+      - run: npm ci
+        working-directory: mcp-server
+      - name: Sync version from git tag
+        working-directory: mcp-server
+        run: npm version "${GITHUB_REF_NAME#v}" --no-git-tag-version
+      - name: Publish to npm
+        working-directory: mcp-server
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          TAG="latest"
+          if echo "${GITHUB_REF_NAME}" | grep -qE '[-]'; then
+            TAG="next"
+          fi
+          npm publish --access public --tag "$TAG"

--- a/docs/0-requirements.md
+++ b/docs/0-requirements.md
@@ -197,13 +197,15 @@ Node.js >= 18.0.0 が必要。
 |---------|--------|------|
 | `v*` タグ push | build-mcpb | `mcpb pack` で .mcpb 生成 |
 | `v*` タグ push | release | GitHub Release 作成 + .mcpb 添付 |
+| `v*` タグ push | npm-publish | npm レジストリに公開 |
 
 リリースフロー:
-1. `npm version patch/minor/major` で package.json 更新 + `v*` タグ作成
-2. `git push origin main --tags` でタグ push
-3. CD が自動実行: .mcpb 生成 → release 作成 → .mcpb 添付
+1. `v*` タグを push する
+2. CD が自動実行: .mcpb 生成 → release 作成 → .mcpb 添付 → npm publish
+3. npm publish 時にタグ名から自動でバージョンを同期する（package.json の手動更新不要）
+4. プレリリースタグ（`-` を含む）は `next` dist-tag で公開、正式リリースは `latest` で公開
 
-バージョン管理は npm (package.json) が正。manifest.json のバージョンも一致させる。
+manifest.json のバージョンも一致させる。
 
 ## Infrastructure
 


### PR DESCRIPTION
Refs #65
CD ワークフローに npm publish ステップを追加。タグ名からバージョンを自動同期し、プレリリースタグは next dist-tag で公開する。