### PR TITLE
Change manifest support URL from issues to discussions

### DIFF
--- a/mcp-server/manifest.json
+++ b/mcp-server/manifest.json
@@ -15,7 +15,7 @@
   },
   "homepage": "https://github.com/Liplus-Project/github-webhook-mcp",
   "documentation": "https://github.com/Liplus-Project/github-webhook-mcp#readme",
-  "support": "https://github.com/Liplus-Project/github-webhook-mcp/issues",
+  "support": "https://github.com/Liplus-Project/github-webhook-mcp/discussions",
   "license": "MIT",
   "server": {
     "type": "node",


### PR DESCRIPTION
Refs #96

manifest.json の support フィールドを `/issues` から `/discussions` に変更。
公開 App のユーザー向けサポート窓口として Discussions が適切であるため。