### PR TITLE
Update default Worker URL to custom domain

### DIFF
--- a/local-mcp/src/index.ts
+++ b/local-mcp/src/index.ts
@@ -22,7 +22,7 @@ import { readFile, writeFile, mkdir } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
-const WORKER_URL = process.env.WEBHOOK_WORKER_URL || "https://github-webhook-mcp.liplus.workers.dev";
+const WORKER_URL = process.env.WEBHOOK_WORKER_URL || "https://github-webhook.smgjp.com";
 const CHANNEL_ENABLED = process.env.WEBHOOK_CHANNEL !== "0";
 // Legacy auth support: if WEBHOOK_AUTH_TOKEN is set, use Bearer token directly
 const LEGACY_AUTH_TOKEN = process.env.WEBHOOK_AUTH_TOKEN || "";

--- a/mcp-server/server/index.js
+++ b/mcp-server/server/index.js
@@ -24,7 +24,7 @@ import { exec } from "node:child_process";
 
 const WORKER_URL =
   process.env.WEBHOOK_WORKER_URL ||
-  "https://github-webhook-mcp.liplus.workers.dev";
+  "https://github-webhook.smgjp.com";
 const CHANNEL_ENABLED = process.env.WEBHOOK_CHANNEL !== "0";
 // Legacy auth support: if WEBHOOK_AUTH_TOKEN is set, use Bearer token directly
 const LEGACY_AUTH_TOKEN = process.env.WEBHOOK_AUTH_TOKEN || "";


### PR DESCRIPTION
Refs #98

デフォルトの Worker URL フォールバック値を `github-webhook-mcp.liplus.workers.dev` から `github-webhook.smgjp.com` に更新。
カスタムドメインは Cloudflare Workers に設定済みで、GitHub App の各 URL もブラウザで更新済み。
コード側のフォールバックを合わせる変更。