### PR TITLE
Remove OAuth fallback manual URL display

### DIFF
--- a/local-mcp/src/index.ts
+++ b/local-mcp/src/index.ts
@@ -221,7 +221,7 @@ async function performOAuthFlow(): Promise<TokenData> {
     });
 
     process.stderr.write(
-      `\n[github-webhook-mcp] Open this URL to authenticate:\n${authUrl.toString()}\n\n`,
+      `\n[github-webhook-mcp] Opening browser for authentication...\n`,
     );
   });
 

--- a/mcp-server/server/index.js
+++ b/mcp-server/server/index.js
@@ -247,7 +247,7 @@ async function startOAuthFlow() {
   // Try to open the browser
   openBrowser(authUrl.toString());
   process.stderr.write(
-    `\n[github-webhook-mcp] Open this URL to authenticate:\n${authUrl.toString()}\n\n`,
+    `\n[github-webhook-mcp] Opening browser for authentication...\n`,
   );
 
   // Store pending state so subsequent tool calls can await or re-surface the URL
@@ -531,7 +531,7 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
         content: [
           {
             type: "text",
-            text: `Authentication required. Please open this URL to authorize:\n${err.authUrl}\n\nAfter authorizing in the browser, retry the tool call.`,
+            text: `Authentication required. A browser window should have opened for authorization. After authorizing in the browser, retry the tool call.`,
           },
         ],
         isError: true,


### PR DESCRIPTION
Refs #104

OAuth認証フローにおけるstderrへの手動URL出力と、OAuthPendingErrorレスポンスでのURL表示を削除。
ブラウザ自動オープンは維持し、ユーザーへのメッセージをブラウザが開いた旨の案内に変更。

Part of #100