### PR TITLE
feat(shared): add workflow_run event summary fields

### DIFF
--- a/shared/src/summarize.ts
+++ b/shared/src/summarize.ts
@@ -36,6 +36,16 @@ function eventUrl(payload: Record<string, unknown>): string | null {
   ) as string | null;
 }
 
+function extractWorkflowRunField(
+  eventType: string,
+  payload: Record<string, unknown>,
+  field: string,
+): string | null {
+  if (eventType !== "workflow_run") return null;
+  const workflowRun = payload.workflow_run as Record<string, unknown> | undefined;
+  return (workflowRun?.[field] as string) ?? null;
+}
+
 export function summarizeEvent(event: WebhookEvent): EventSummary {
   const payload = event.payload || {};
   return {
@@ -51,5 +61,8 @@ export function summarizeEvent(event: WebhookEvent): EventSummary {
     number: eventNumber(payload),
     title: eventTitle(payload),
     url: eventUrl(payload),
+    head_branch: extractWorkflowRunField(event.type, payload, "head_branch"),
+    head_sha: extractWorkflowRunField(event.type, payload, "head_sha"),
+    conclusion: extractWorkflowRunField(event.type, payload, "conclusion"),
   };
 }

--- a/shared/src/types.ts
+++ b/shared/src/types.ts
@@ -28,6 +28,10 @@ export interface EventSummary {
   number: number | null;
   title: string | null;
   url: string | null;
+  /** workflow_run specific fields (null for other event types) */
+  head_branch: string | null;
+  head_sha: string | null;
+  conclusion: string | null;
 }
 
 /** Response from get_pending_status */


### PR DESCRIPTION
Refs #94

workflow_run イベントの EventSummary に head_branch, head_sha, conclusion フィールドを追加。
worker は既に全 webhook イベントを汎用的に受信・保存しており、summarizeEvent の eventTitle / eventUrl でも workflow_run.name / html_url を抽出済みだったが、CI/CD 判定に必要な固有フィールドが欠落していた。
extractWorkflowRunField ヘルパーを追加し、workflow_run イベント時のみ値を返す。他イベントでは null。