### PR TITLE
feat(worker): auto-process self-action webhook notifications at ingest time

### DIFF
--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -12,7 +12,7 @@
  *
  * Routes (defaultHandler, no OAuth token required):
  *   POST /webhooks/github — GitHub webhook receiver
- *     Auth chain: IP allowlist → rate limit → signature → tenant → quota
+ *     Auth chain: IP allowlist → rate limit → signature → tenant → quota → self-action → store
  *   GET  /oauth/authorize  — Start GitHub OAuth flow
  *   GET  /oauth/callback   — GitHub OAuth callback
  */
@@ -36,6 +36,7 @@ interface Env extends OAuthEnv {
   WEBHOOK_STORE: DurableObjectNamespace;
   TENANT_REGISTRY: DurableObjectNamespace;
   GITHUB_WEBHOOK_SECRET?: string;
+  GITHUB_APP_SLUG?: string;
 }
 
 async function verifyGitHubSignature(
@@ -56,6 +57,37 @@ async function verifyGitHubSignature(
     .map((b) => b.toString(16).padStart(2, "0"))
     .join("");
   return expected === signature;
+}
+
+/**
+ * Determine whether a webhook event is a self-action (triggered by the
+ * GitHub App's bot account or the installation owner account).
+ *
+ * Self-action events are still stored for audit/history, but marked as
+ * processed immediately so they don't appear in pending lists.
+ *
+ * @param senderLogin  - payload.sender.login
+ * @param senderType   - payload.sender.type ("User" | "Bot" | "Organization" | ...)
+ * @param accountLogin - installation owner account login (from TenantRegistry)
+ * @param appSlug      - optional GITHUB_APP_SLUG env var
+ */
+function isSelfAction(
+  senderLogin: string | undefined,
+  senderType: string | undefined,
+  accountLogin: string,
+  appSlug: string | undefined,
+): boolean {
+  if (!senderLogin) return false;
+
+  // Match: installation owner triggered the event
+  if (senderLogin === accountLogin) return true;
+
+  // Match: GitHub App bot account — follows the pattern "{app-slug}[bot]"
+  if (appSlug && senderType === "Bot" && senderLogin === `${appSlug}[bot]`) {
+    return true;
+  }
+
+  return false;
 }
 
 /**
@@ -148,7 +180,8 @@ const innerHandler: ExportedHandler<Env> = {
     //   3. Signature verification (requires body read + HMAC)
     //   4. Tenant resolution (DO call)
     //   5. Per-tenant quota check (DO call, atomic increment)
-    //   6. Forward to WebhookStore DO
+    //   6. Self-action detection
+    //   7. Forward to WebhookStore DO
     // Each layer blocks before the next to minimize DO calls on invalid requests.
     if (url.pathname === "/webhooks/github" && request.method === "POST") {
       // 1. IP allowlist — block non-GitHub IPs before any processing
@@ -212,7 +245,17 @@ const innerHandler: ExportedHandler<Env> = {
         }
       }
 
-      // 6. Forward to tenant-specific WebhookStore DO (store-{accountId})
+      // 6. Self-action detection — mark bot / installation-owner events as processed
+      //    Events are still stored for audit/history but won't appear in pending lists.
+      const sender = payload.sender as { login?: string; type?: string } | undefined;
+      const selfAction = isSelfAction(
+        sender?.login,
+        sender?.type,
+        tenant.account_login,
+        env.GITHUB_APP_SLUG,
+      );
+
+      // 7. Forward to tenant-specific WebhookStore DO (store-{accountId})
       const storeName = `store-${tenant.account_id}`;
       const doId = env.WEBHOOK_STORE.idFromName(storeName);
       const stub = env.WEBHOOK_STORE.get(doId);
@@ -224,14 +267,14 @@ const innerHandler: ExportedHandler<Env> = {
             id: deliveryId,
             type: eventType,
             received_at: new Date().toISOString(),
-            processed: false,
+            processed: selfAction,
             payload,
           }),
         }),
       );
 
       return new Response(
-        JSON.stringify({ accepted: true, id: deliveryId }),
+        JSON.stringify({ accepted: true, id: deliveryId, self_action: selfAction }),
         {
           status: 202,
           headers: { "Content-Type": "application/json" },

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -29,6 +29,8 @@ id = "PLACEHOLDER_KV_ID"
 # GITHUB_CLIENT_ID      — GitHub App OAuth client ID
 # GITHUB_CLIENT_SECRET   — GitHub App OAuth client secret
 # GITHUB_WEBHOOK_SECRET  — Webhook HMAC secret (shared with GitHub App settings)
+# GITHUB_APP_SLUG        — (optional) GitHub App slug for self-action detection
+#                          When set, webhooks from {slug}[bot] are auto-processed
 
 # ─── WAF / Firewall Rule Setup (Cloudflare Dashboard) ───────────────
 #


### PR DESCRIPTION
Refs #95

webhook 受信時（ingest）に sender を検査し、セルフアクション通知を自動的に processed としてマークする機能を worker に追加。

セルフアクション判定基準:
- sender.login がインストール先アカウント（account_login）と一致
- sender.login が `{GITHUB_APP_SLUG}[bot]` パターンに一致（Bot タイプ）

イベントは監査用に保存されるが、pending リストには表示されない。外部ユーザーからのイベントは従来通り unprocessed のまま保持される。

`GITHUB_APP_SLUG` 環境変数（任意）で App bot アカウント判定を有効化。