### PR TITLE
fix: add missing tool, fix docs, clean up dead code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,4 @@
 .env
-events.json
-trigger-events/
-codex-runs/
-__pycache__/
-*.pyc
 mcp-server/node_modules/
 mcp-server/*.mcpb
 worker/node_modules/

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -104,7 +104,7 @@ Enter the secret value when prompted. Keep this value -- you will need it when c
 If your deployment uses OAuth-based authentication:
 
 1. In the GitHub App settings, set the **Callback URL** to:
-   `https://github-webhook-mcp.example.workers.dev/auth/callback`
+   `https://github-webhook-mcp.example.workers.dev/oauth/callback`
 2. Generate a client secret and store it as a Cloudflare secret
 
 ### 5. Custom domain (optional)

--- a/local-mcp/src/index.ts
+++ b/local-mcp/src/index.ts
@@ -458,6 +458,20 @@ const TOOLS = [
     },
   },
   {
+    name: "get_webhook_events",
+    description:
+      "Get pending (unprocessed) GitHub webhook events with full payloads. Prefer get_pending_status or list_pending_events for polling.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        limit: {
+          type: "number",
+          description: "Max events to return (1-100, default 20)",
+        },
+      },
+    },
+  },
+  {
     name: "mark_processed",
     description: "Mark a webhook event as processed",
     inputSchema: {

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -2,7 +2,6 @@ export type {
   WebhookEvent,
   EventSummary,
   PendingStatus,
-  SSEEvent,
 } from "./types.js";
 
 export { summarizeEvent } from "./summarize.js";

--- a/shared/src/types.ts
+++ b/shared/src/types.ts
@@ -40,10 +40,3 @@ export interface PendingStatus {
   latest_received_at: string | null;
   types: Record<string, number>;
 }
-
-/** SSE event pushed from Worker to local bridge */
-export interface SSEEvent {
-  event_id: string;
-  type: string;
-  summary: EventSummary;
-}

--- a/worker/src/agent.ts
+++ b/worker/src/agent.ts
@@ -24,7 +24,6 @@ interface Env {
 export interface TenantProps {
   account_id?: number;
   account_login?: string;
-  account_type?: string;
   /** All account IDs (user + orgs) whose stores this session can read */
   accessible_account_ids?: number[];
 }


### PR DESCRIPTION
## 概要

コードベース監査で見つかった3件を修正。

- local-mcp TOOLS リストに `get_webhook_events` を追加（worker/mcp-server と揃える）
- docs/installation.md の OAuth コールバック URL を `/auth/callback` → `/oauth/callback` に修正
- 未使用コード削除（SSEEvent 型、TenantProps.account_type）
- .gitignore から旧 Python アーキテクチャのエントリを削除

Refs #111
Refs #112
Refs #113

## テスト計画

- [ ] local-mcp で tools/list に get_webhook_events が含まれることを確認
- [ ] OAuth フローが正常に動作することを確認