### PR TITLE
fix: remove legacy WEBHOOK_AUTH_TOKEN support

### DIFF
--- a/local-mcp/src/index.ts
+++ b/local-mcp/src/index.ts
@@ -24,8 +24,6 @@ import { join } from "node:path";
 
 const WORKER_URL = process.env.WEBHOOK_WORKER_URL || "https://github-webhook.smgjp.com";
 const CHANNEL_ENABLED = process.env.WEBHOOK_CHANNEL !== "0";
-// Legacy auth support: if WEBHOOK_AUTH_TOKEN is set, use Bearer token directly
-const LEGACY_AUTH_TOKEN = process.env.WEBHOOK_AUTH_TOKEN || "";
 
 // ── OAuth Token Storage ──────────────────────────────────────────────────────
 
@@ -302,9 +300,6 @@ async function refreshAccessToken(refreshToken: string): Promise<TokenData> {
  * Get a valid access token, refreshing or re-authenticating as needed.
  */
 async function getAccessToken(): Promise<string> {
-  // Legacy mode: use static token if configured
-  if (LEGACY_AUTH_TOKEN) return LEGACY_AUTH_TOKEN;
-
   if (!_cachedTokens) {
     _cachedTokens = await loadTokens();
   }

--- a/mcp-server/manifest.json
+++ b/mcp-server/manifest.json
@@ -27,8 +27,7 @@
       ],
       "env": {
         "WEBHOOK_WORKER_URL": "${user_config.worker_url}",
-        "WEBHOOK_CHANNEL": "${user_config.channel_enabled}",
-        "WEBHOOK_AUTH_TOKEN": "${user_config.auth_token}"
+        "WEBHOOK_CHANNEL": "${user_config.channel_enabled}"
       }
     }
   },
@@ -45,13 +44,6 @@
       "required": false,
       "title": "Channel Notifications",
       "default": "0"
-    },
-    "auth_token": {
-      "description": "Legacy Bearer token for self-hosted workers without OAuth. Leave empty to use OAuth authentication (recommended).",
-      "type": "string",
-      "required": false,
-      "title": "Auth Token (Legacy)",
-      "default": ""
     }
   },
   "tools": [

--- a/mcp-server/server/index.js
+++ b/mcp-server/server/index.js
@@ -26,8 +26,6 @@ const WORKER_URL =
   process.env.WEBHOOK_WORKER_URL ||
   "https://github-webhook.smgjp.com";
 const CHANNEL_ENABLED = process.env.WEBHOOK_CHANNEL !== "0";
-// Legacy auth support: if WEBHOOK_AUTH_TOKEN is set, use Bearer token directly
-const LEGACY_AUTH_TOKEN = process.env.WEBHOOK_AUTH_TOKEN || "";
 
 // ── OAuth Token Storage ──────────────────────────────────────────────────────
 
@@ -314,8 +312,6 @@ async function refreshAccessToken(refreshToken) {
 }
 
 async function getAccessToken() {
-  if (LEGACY_AUTH_TOKEN) return LEGACY_AUTH_TOKEN;
-
   if (!_cachedTokens) {
     _cachedTokens = await loadTokens();
   }


### PR DESCRIPTION
## 概要

レガシー WEBHOOK_AUTH_TOKEN サポートを完全削除。

- local-mcp/src/index.ts: LEGACY_AUTH_TOKEN 定数と getAccessToken 内のフォールバック削除
- mcp-server/server/index.js: 同上
- mcp-server/manifest.json: auth_token user_config と env 参照を削除

Worker 側は OAuth に完全移行済みで、レガシートークンのハンドラは存在しなかった。

Refs #113

## テスト計画

- [ ] OAuth フローが正常に動作することを確認
- [ ] WEBHOOK_AUTH_TOKEN 環境変数なしで正常起動することを確認