### PR TITLE
fix(manifest): change channel_enabled default to match code behavior

### DIFF
--- a/mcp-server/manifest.json
+++ b/mcp-server/manifest.json
@@ -43,7 +43,7 @@
       "type": "string",
       "required": false,
       "title": "Channel Notifications",
-      "default": "0"
+      "default": "1"
     }
   },
   "tools": [


### PR DESCRIPTION
Refs #120

manifest.jsonの`channel_enabled`デフォルト値`"0"`がserver/index.jsのコードデフォルト（未設定=有効）と矛盾していた。
manifest経由でClaude Codeが起動するとチャンネル通知が暗黙的に無効化される問題を修正。
デフォルト値を`"1"`に変更し、コード側の動作と整合性を確保。