### PR TITLE
fix: use Authorization header for SSE channel auth [#124]

### DIFF
--- a/mcp-server/server/index.js
+++ b/mcp-server/server/index.js
@@ -590,8 +590,10 @@ async function connectSSE() {
       return;
     }
 
-    const sseUrl = `${WORKER_URL}/events?token=${encodeURIComponent(token)}`;
-    const es = new EventSourceImpl(sseUrl);
+    const sseUrl = `${WORKER_URL}/events`;
+    const es = new EventSourceImpl(sseUrl, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
 
     es.onopen = () => {
       retryCount = 0; // Reset backoff on successful connection


### PR DESCRIPTION
Refs #124
SSEチャンネル認証を `?token=` クエリパラメータから `Authorization: Bearer` ヘッダーへ変更し、Worker OAuthProviderによる401エラーを解消する。