### PR TITLE
fix: add F5.4 required meta fields to local-mcp channel notification

### DIFF
--- a/local-mcp/src/index.ts
+++ b/local-mcp/src/index.ts
@@ -572,6 +572,10 @@ async function connectWebSocket() {
           params: {
             content: parts.join(" "),
             meta: {
+              chat_id: "github",
+              message_id: s.id,
+              user: s.sender ?? "github",
+              ts: s.received_at,
               event_id: s.id,
               type: s.type,
               ...(s.repo ? { repo: s.repo } : {}),


### PR DESCRIPTION
Refs #127

local-mcp のチャンネル通知メタに仕様 F5.4 必須フィールドを追加し、mcp-server と統一。
Claude Code CLI がチャンネルとして正しく認識できない問題を修正。

- `chat_id: "github"` — チャンネルソース識別子を追加
- `message_id: s.id` — `event_id` と同値だが F5.4 準拠名で追加
- `user: s.sender ?? "github"` — 送信者情報を追加
- `ts: s.received_at` — タイムスタンプを追加