### PR TITLE
fix: replace PLACEHOLDER_KV_ID with actual KV namespace ID

### DIFF
--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -21,9 +21,7 @@ new_sqlite_classes = ["TenantRegistry"]
 # KV namespace for OAuth provider (token, client, grant storage)
 [[kv_namespaces]]
 binding = "OAUTH_KV"
-id = "PLACEHOLDER_KV_ID"
-# After creating the KV namespace with `wrangler kv namespace create OAUTH_KV`,
-# replace PLACEHOLDER_KV_ID with the actual namespace ID.
+id = "67611ab57f734f1c9a0b5d5a96f65e78"
 
 # Required secrets (set via `wrangler secret put <NAME>`):
 # GITHUB_CLIENT_ID      — GitHub App OAuth client ID


### PR DESCRIPTION
## Summary
- wrangler.toml の OAUTH_KV namespace ID をプレースホルダーから実際の ID に置換
- Cloudflare Workers Git integration によるデプロイが `KV namespace 'PLACEHOLDER_KV_ID' is not valid` で失敗する問題を修正

🤖 Generated with [Claude Code](https://claude.com/claude-code)