### PR TITLE
feat: add MCP official registry metadata

### DIFF
--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -9,7 +9,8 @@
   "main": "./server/index.js",
   "files": [
     "server/",
-    "manifest.json"
+    "manifest.json",
+    "server.json"
   ],
   "scripts": {
     "start": "node server/index.js",
@@ -32,6 +33,7 @@
     "webhook",
     "cloudflare"
   ],
+  "mcpName": "io.github.liplus-project/github-webhook-mcp",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/mcp-server/server.json
+++ b/mcp-server/server.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-07-09/server.schema.json",
+  "name": "io.github.liplus-project/github-webhook-mcp",
+  "description": "MCP server bridging GitHub webhooks via Cloudflare Worker for real-time event streaming",
+  "version": "1.0.0",
+  "repository": {
+    "url": "https://github.com/Liplus-Project/github-webhook-mcp",
+    "source": "github",
+    "id": "1175626622",
+    "subfolder": "mcp-server"
+  },
+  "packages": [
+    {
+      "registry_type": "npm",
+      "identifier": "github-webhook-mcp",
+      "version": "1.0.0",
+      "runtime_hint": "npx",
+      "transport": {
+        "type": "stdio"
+      },
+      "environment_variables": [
+        {
+          "name": "WEBHOOK_WORKER_URL",
+          "description": "URL of your deployed Cloudflare Worker endpoint (default: https://github-webhook.smgjp.com)",
+          "is_required": false
+        },
+        {
+          "name": "WEBHOOK_CHANNEL",
+          "description": "Set to '0' to disable SSE channel notifications (default: enabled)",
+          "is_required": false
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Refs #136

MCP公式レジストリ登録に必要なメタデータファイルを追加。
- `mcpName` フィールドを package.json に追加（npm所有権証明用）
- `server.json` を新規作成（レジストリスキーマ 2025-07-09 準拠）
- `server.json` を package.json の files に追加（npm パッケージに含める）