### PR TITLE
Bump version to 0.8.0 for MCP registry release

### DIFF
--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "github-webhook-mcp",
-  "version": "1.0.0",
+  "version": "0.8.0",
   "description": "MCP server bridging GitHub webhooks via Cloudflare Worker",
   "type": "module",
   "bin": {

--- a/mcp-server/server.json
+++ b/mcp-server/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-07-09/server.schema.json",
   "name": "io.github.liplus-project/github-webhook-mcp",
   "description": "MCP server bridging GitHub webhooks via Cloudflare Worker for real-time event streaming",
-  "version": "1.0.0",
+  "version": "0.8.0",
   "repository": {
     "url": "https://github.com/Liplus-Project/github-webhook-mcp",
     "source": "github",
@@ -13,7 +13,7 @@
     {
       "registry_type": "npm",
       "identifier": "github-webhook-mcp",
-      "version": "1.0.0",
+      "version": "0.8.0",
       "runtime_hint": "npx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
Refs #138

squash merge (#137) で失われた server.json のバージョン修正を含め、package.json / server.json の全 version フィールドを 0.8.0 に統一。