### PR TITLE
fix(cd): add --allow-same-version to npm version sync

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -53,7 +53,7 @@ jobs:
         working-directory: mcp-server
       - name: Sync version from git tag
         working-directory: mcp-server
-        run: npm version "${GITHUB_REF_NAME#v}" --no-git-tag-version
+        run: npm version "${GITHUB_REF_NAME#v}" --no-git-tag-version --allow-same-version
       - name: Publish to npm
         working-directory: mcp-server
         env:


### PR DESCRIPTION
Refs #140

npm-publish ジョブの `npm version` コマンドに `--allow-same-version` フラグを追加。
package.json のバージョンがタグと既に一致している場合でもエラーにならないようにする。