### PR TITLE
Bump version to 0.8.1 (package.json, server.json)

### DIFF
--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "github-webhook-mcp",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "MCP server bridging GitHub webhooks via Cloudflare Worker",
   "type": "module",
   "bin": {

--- a/mcp-server/server.json
+++ b/mcp-server/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-07-09/server.schema.json",
   "name": "io.github.liplus-project/github-webhook-mcp",
   "description": "MCP server bridging GitHub webhooks via Cloudflare Worker for real-time event streaming",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "repository": {
     "url": "https://github.com/Liplus-Project/github-webhook-mcp",
     "source": "github",
@@ -13,7 +13,7 @@
     {
       "registry_type": "npm",
       "identifier": "github-webhook-mcp",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "runtime_hint": "npx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
Refs #142

v0.8.0 の CD npm-publish 失敗を受け、package.json と server.json の version を 0.8.1 に更新。
マージ後に v0.8.1 タグを切ることで、修正済み cd.yml による CD が実行される。