### PR TITLE
fix(registry): correct MCP namespace casing to match GitHub org

### DIFF
--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -33,7 +33,7 @@
     "webhook",
     "cloudflare"
   ],
-  "mcpName": "io.github.liplus-project/github-webhook-mcp",
+  "mcpName": "io.github.Liplus-Project/github-webhook-mcp",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/mcp-server/server.json
+++ b/mcp-server/server.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-  "name": "io.github.liplus-project/github-webhook-mcp",
+  "name": "io.github.Liplus-Project/github-webhook-mcp",
   "description": "MCP server bridging GitHub webhooks via Cloudflare Worker for real-time event streaming",
   "version": "0.8.1",
   "repository": {


### PR DESCRIPTION
Refs #146

MCP レジストリ名前空間 `io.github.liplus-project/...` を `io.github.Liplus-Project/...` に修正。
GitHub org 名との大文字小文字不一致が `mcp-publisher publish` の 403 エラーの原因。