### PR TITLE
Bump version to 0.8.2 for npm mcpName casing fix

### DIFF
--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "github-webhook-mcp",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "MCP server bridging GitHub webhooks via Cloudflare Worker",
   "type": "module",
   "bin": {

--- a/mcp-server/server.json
+++ b/mcp-server/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.Liplus-Project/github-webhook-mcp",
   "description": "MCP server bridging GitHub webhooks via Cloudflare Worker for real-time event streaming",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "repository": {
     "url": "https://github.com/Liplus-Project/github-webhook-mcp",
     "source": "github",
@@ -13,7 +13,7 @@
     {
       "registryType": "npm",
       "identifier": "github-webhook-mcp",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
Refs #148

npm v0.8.1 にはまだ旧 mcpName（小文字）が含まれているため、mcp-publisher の検証を通すために v0.8.2 をリリースする。package.json の version と server.json の version / packages[0].version を 0.8.2 に更新。