### PR TITLE
Split CD trigger: tag push creates release, release published triggers CD

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,14 +1,16 @@
 name: CD
 
 on:
-  push:
-    tags: ["v*"]
+  release:
+    types: [published]
 
 jobs:
   build-mcpb:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.release.tag_name }}
       - uses: actions/setup-node@v6
         with:
           node-version: "24"
@@ -21,46 +23,32 @@ jobs:
           name: mcpb
           path: mcp-server/*.mcpb
 
-  release:
-    runs-on: ubuntu-latest
-    needs: build-mcpb
-    permissions:
-      contents: write
-    steps:
-      - uses: actions/checkout@v6
-      - uses: actions/download-artifact@v8
-        with:
-          name: mcpb
-          path: dist/
-      - name: Create release with .mcpb
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh release create "${{ github.ref_name }}" dist/*.mcpb \
-            --title "${{ github.ref_name }}" \
-            --generate-notes
-
   npm-publish:
     runs-on: ubuntu-latest
-    needs: release
+    needs: build-mcpb
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.release.tag_name }}
       - uses: actions/setup-node@v6
         with:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"
       - run: npm ci
         working-directory: mcp-server
-      - name: Sync version from git tag
+      - name: Sync version from release tag
         working-directory: mcp-server
-        run: npm version "${GITHUB_REF_NAME#v}" --no-git-tag-version --allow-same-version
+        run: npm version "${TAG_NAME#v}" --no-git-tag-version --allow-same-version
+        env:
+          TAG_NAME: ${{ github.event.release.tag_name }}
       - name: Publish to npm
         working-directory: mcp-server
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          TAG_NAME: ${{ github.event.release.tag_name }}
         run: |
           TAG="latest"
-          if echo "${GITHUB_REF_NAME}" | grep -qE '[-]'; then
+          if echo "${TAG_NAME}" | grep -qE '[-]'; then
             TAG="next"
           fi
           npm publish --access public --tag "$TAG"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,41 @@
+name: Release
+
+on:
+  push:
+    tags: ["v*"]
+
+jobs:
+  build-mcpb:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+      - run: npm ci
+        working-directory: mcp-server
+      - run: npx mcpb pack
+        working-directory: mcp-server
+      - uses: actions/upload-artifact@v7
+        with:
+          name: mcpb
+          path: mcp-server/*.mcpb
+
+  create-release:
+    runs-on: ubuntu-latest
+    needs: build-mcpb
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/download-artifact@v8
+        with:
+          name: mcpb
+          path: dist/
+      - name: Create release with .mcpb
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${{ github.ref_name }}" dist/*.mcpb \
+            --title "${{ github.ref_name }}" \
+            --generate-notes

--- a/docs/0-requirements.md
+++ b/docs/0-requirements.md
@@ -221,19 +221,26 @@ Node.js >= 18.0.0 が必要。
 |---------|--------|------|
 | PR to main / push to main | test | Node.js syntax check |
 
-### リリース（CD）
+### リリース作成（Release）
 
 | トリガー | ジョブ | 内容 |
 |---------|--------|------|
 | `v*` タグ push | build-mcpb | `mcpb pack` で .mcpb 生成 |
-| `v*` タグ push | release | GitHub Release 作成 + .mcpb 添付 |
-| `v*` タグ push | npm-publish | npm レジストリに公開 |
+| `v*` タグ push | create-release | GitHub Release 作成 + .mcpb 添付 |
+
+### デプロイ（CD）
+
+| トリガー | ジョブ | 内容 |
+|---------|--------|------|
+| release published | build-mcpb | `mcpb pack` で .mcpb 生成 |
+| release published | npm-publish | npm レジストリに公開 |
 
 リリースフロー:
 1. `v*` タグを push する
-2. CD が自動実行: .mcpb 生成 → release 作成 → .mcpb 添付 → npm publish
-3. npm publish 時にタグ名から自動でバージョンを同期する（package.json の手動更新不要）
-4. プレリリースタグ（`-` を含む）は `next` dist-tag で公開、正式リリースは `latest` で公開
+2. Release ワークフローが自動実行: .mcpb 生成 → GitHub Release 作成 + .mcpb 添付
+3. Release published イベントで CD ワークフローが発火: .mcpb 生成 → npm publish
+4. npm publish 時にリリースタグ名から自動でバージョンを同期する（package.json の手動更新不要）
+5. プレリリースタグ（`-` を含む）は `next` dist-tag で公開、正式リリースは `latest` で公開
 
 manifest.json のバージョンも一致させる。
 


### PR DESCRIPTION
Refs #151

CD ワークフローの発火条件を tag push から release published に変更し、リリース作成を別ワークフローに分離。
tag 時点のワークフロー定義が使われる問題を解消し、最新の main のワークフローで CD が実行されるようにした。