### PR TITLE
feat(cd): add attach-mcpb job to upload .mcpb to release

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -23,6 +23,22 @@ jobs:
           name: mcpb
           path: mcp-server/*.mcpb
 
+  attach-mcpb:
+    runs-on: ubuntu-latest
+    needs: build-mcpb
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: mcpb
+          path: dist
+      - name: Upload mcpb to release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG_NAME: ${{ github.event.release.tag_name }}
+        run: gh release upload "$TAG_NAME" dist/*.mcpb --clobber --repo "${{ github.repository }}"
+
   npm-publish:
     runs-on: ubuntu-latest
     needs: build-mcpb

--- a/docs/0-requirements.md
+++ b/docs/0-requirements.md
@@ -226,11 +226,12 @@ Node.js >= 18.0.0 が必要。
 | トリガー | ジョブ | 内容 |
 |---------|--------|------|
 | release published | build-mcpb | `mcpb pack` で .mcpb 生成 |
+| release published | attach-mcpb | `gh release upload` で .mcpb をリリースに添付（build-mcpb 後） |
 | release published | npm-publish | npm レジストリに公開 |
 
 リリースフロー:
 1. AI が `gh release create` でリリースを作成する（PAT 経由で release イベントが発火する）
-2. Release published イベントで CD ワークフローが発火: .mcpb 生成 → npm publish
+2. Release published イベントで CD ワークフローが発火: .mcpb 生成 → .mcpb リリース添付 → npm publish
 3. npm publish 時にリリースタグ名から自動でバージョンを同期する（package.json の手動更新不要）
 4. プレリリースタグ（`-` を含む）は `next` dist-tag で公開、正式リリースは `latest` で公開
 


### PR DESCRIPTION
Refs #151

CD ワークフローに attach-mcpb ジョブを追加。build-mcpb 完了後に `gh release upload` で .mcpb アーティファクトを既存 GitHub Release に添付する。#160 で release ジョブ削除時に失われた機能の復元。