### PR TITLE
fix(cd): sync manifest.json version from release tag in build-mcpb job

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -16,6 +16,11 @@ jobs:
           node-version: "24"
       - run: npm ci
         working-directory: mcp-server
+      - name: Sync manifest.json version from release tag
+        working-directory: mcp-server
+        env:
+          TAG_NAME: ${{ github.event.release.tag_name }}
+        run: jq --arg v "${TAG_NAME#v}" '.version = $v' manifest.json > manifest.tmp && mv manifest.tmp manifest.json
       - run: npx mcpb pack
         working-directory: mcp-server
       - uses: actions/upload-artifact@v7


### PR DESCRIPTION
## Summary

- build-mcpb ジョブで `npx mcpb pack` の前に `jq` で manifest.json の version を release tag から同期するステップを追加
- npm-publish ジョブの既存パターン (`npm version`) に合わせた方式
- リポジトリ内の manifest.json 自体は変更せず、CI 上でのみ書き換え

Closes #162