### PR TITLE
fix(mcp-server): use ws package for WebSocket auth headers

### DIFF
--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "github-webhook-mcp",
-  "version": "1.0.0",
+  "version": "0.8.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "github-webhook-mcp",
-      "version": "1.0.0",
+      "version": "0.8.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",
-        "eventsource": "^2.0.2"
+        "ws": "^8.18.0"
       },
       "bin": {
         "github-webhook-mcp": "server/index.js"
@@ -744,15 +744,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/eventsource": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-2.0.2.tgz",
-      "integrity": "sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.0.0"
       }
     },
     "node_modules/eventsource-parser": {
@@ -1777,6 +1768,27 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/yoctocolors-cjs": {
       "version": "2.1.3",

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -18,7 +18,8 @@
     "pack:mcpb": "mcpb pack"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.0.0"
+    "@modelcontextprotocol/sdk": "^1.0.0",
+    "ws": "^8.18.0"
   },
   "devDependencies": {
     "@anthropic-ai/mcpb": "^2.1.0"

--- a/mcp-server/server/index.js
+++ b/mcp-server/server/index.js
@@ -23,6 +23,7 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import { exec } from "node:child_process";
 import { createRequire } from "node:module";
+import WebSocketClient from "ws";
 
 const require = createRequire(import.meta.url);
 const { version: PACKAGE_VERSION } = require("../package.json");
@@ -593,27 +594,27 @@ async function connectWebSocket() {
     let pingTimer = null;
 
     try {
-      ws = new WebSocket(wsUrl, { headers: { Authorization: `Bearer ${token}` } });
+      ws = new WebSocketClient(wsUrl, { headers: { Authorization: `Bearer ${token}` } });
     } catch (err) {
       process.stderr.write(`[github-webhook-mcp] WebSocket: failed to create connection: ${err}\n`);
       scheduleRetry();
       return;
     }
 
-    ws.addEventListener("open", () => {
+    ws.on("open", () => {
       retryCount = 0; // Reset backoff on successful connection
       process.stderr.write("[github-webhook-mcp] WebSocket: connected\n");
       // Send periodic pings to keep connection alive (25s keepalive)
       pingTimer = setInterval(() => {
-        if (ws.readyState === WebSocket.OPEN) {
+        if (ws.readyState === WebSocketClient.OPEN) {
           ws.send("ping");
         }
       }, 25_000);
     });
 
-    ws.addEventListener("message", (event) => {
+    ws.on("message", (raw) => {
       try {
-        const data = JSON.parse(typeof event.data === "string" ? event.data : event.data.toString());
+        const data = JSON.parse(raw.toString());
 
         // Skip status, pong, heartbeat messages
         if ("status" in data || "pong" in data || "heartbeat" in data) return;
@@ -645,10 +646,9 @@ async function connectWebSocket() {
       }
     });
 
-    ws.addEventListener("close", (event) => {
+    ws.on("close", (code) => {
       if (pingTimer) clearInterval(pingTimer);
       pingTimer = null;
-      const code = event.code;
       if (code === 1008 || code === 4401) {
         // Policy violation or unauthorized — refresh token
         process.stderr.write(`[github-webhook-mcp] WebSocket: closed with code ${code}, refreshing token\n`);
@@ -659,8 +659,8 @@ async function connectWebSocket() {
       scheduleRetry();
     });
 
-    ws.addEventListener("error", () => {
-      process.stderr.write("[github-webhook-mcp] WebSocket: connection error\n");
+    ws.on("error", (err) => {
+      process.stderr.write(`[github-webhook-mcp] WebSocket: error: ${err.message}\n`);
       // Will trigger close event, which handles reconnect
     });
   }


### PR DESCRIPTION
Refs #168

Node.js ネイティブ WebSocket API はブラウザ仕様準拠で、コンストラクタの第二引数は protocols のみ。
`{ headers: { Authorization } }` オプションはサイレントに無視されるため、認証ヘッダーが Worker に届かず接続タイムアウトが発生していた。
`ws` npm パッケージに切り替え、local-mcp と同じ接続パターンで認証ヘッダーを正しく送信するよう修正。