### PR TITLE
fix(notice): correct copyright holder name

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,2 +1,2 @@
 github-webhook-mcp
-Copyright 2026 Liplus Project
+Copyright 2026 Yoshiharu Uematsu


### PR DESCRIPTION
## Summary
- NOTICE ファイルの著作権者を Liplus Project → Yoshiharu Uematsu に修正

Refs #172