### PR TITLE
Rename CD artifact from mcp-server.mcpb to github-webhook-mcp.mcpb

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -38,11 +38,13 @@ jobs:
         with:
           name: mcpb
           path: dist
-      - name: Upload mcpb to release
+      - name: Rename and upload mcpb to release
         env:
           GH_TOKEN: ${{ github.token }}
           TAG_NAME: ${{ github.event.release.tag_name }}
-        run: gh release upload "$TAG_NAME" dist/*.mcpb --clobber --repo "${{ github.repository }}"
+        run: |
+          mv dist/mcp-server.mcpb dist/github-webhook-mcp.mcpb
+          gh release upload "$TAG_NAME" dist/github-webhook-mcp.mcpb --clobber --repo "${{ github.repository }}"
 
   npm-publish:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Refs #177

CDワークフローのattach-mcpbジョブで、mcp-server.mcpb を github-webhook-mcp.mcpb にリネームしてからリリースにアップロードするように変更。github-rag-mcp側と命名パターンを統一する。