### PR TITLE
Fix manifest.json license field (mcp-server)

### DIFF
--- a/mcp-server/manifest.json
+++ b/mcp-server/manifest.json
@@ -16,7 +16,7 @@
   "homepage": "https://github.com/Liplus-Project/github-webhook-mcp",
   "documentation": "https://github.com/Liplus-Project/github-webhook-mcp#readme",
   "support": "https://github.com/Liplus-Project/github-webhook-mcp/discussions",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "icon": "icon.png",
   "server": {
     "type": "node",


### PR DESCRIPTION
Refs #181

mcp-server/manifest.json の license フィールドが MIT のまま残っていたため、Apache-2.0 に修正。
v0.9.3 (#172) でプロジェクト全体は Apache-2.0 に切り替え済みだが、manifest.json の更新が漏れていた。