### PR TITLE
Fix auth loop: limit 401/session retry to once, fix empty refresh token

### DIFF
--- a/local-mcp/src/index.ts
+++ b/local-mcp/src/index.ts
@@ -363,7 +363,7 @@ async function getSessionId(): Promise<string> {
   return _sessionId;
 }
 
-async function callRemoteTool(name: string, args: Record<string, unknown>): Promise<{ content: Array<{ type: string; text: string }> }> {
+async function callRemoteTool(name: string, args: Record<string, unknown>, _retried = false): Promise<{ content: Array<{ type: string; text: string }> }> {
   const sessionId = await getSessionId();
 
   const res = await fetch(`${WORKER_URL}/mcp`, {
@@ -381,11 +381,14 @@ async function callRemoteTool(name: string, args: Record<string, unknown>): Prom
     }),
   });
 
-  // 401 = token expired or revoked, re-authenticate and retry
+  // 401 = token expired or revoked, re-authenticate and retry once
   if (res.status === 401) {
+    if (_retried) {
+      return { content: [{ type: "text", text: "Authentication failed after retry. Please re-authenticate." }] };
+    }
     _cachedTokens = null;
     _sessionId = null;
-    return callRemoteTool(name, args);
+    return callRemoteTool(name, args, true);
   }
 
   const text = await res.text();
@@ -396,9 +399,9 @@ async function callRemoteTool(name: string, args: Record<string, unknown>): Prom
 
   if (json.error) {
     // Session expired — retry once with a fresh session
-    if (json.error.code === -32600 || json.error.code === -32001) {
+    if ((json.error.code === -32600 || json.error.code === -32001) && !_retried) {
       _sessionId = null;
-      return callRemoteTool(name, args);
+      return callRemoteTool(name, args, true);
     }
     return { content: [{ type: "text", text: JSON.stringify(json.error) }] };
   }

--- a/mcp-server/server/index.js
+++ b/mcp-server/server/index.js
@@ -378,7 +378,7 @@ async function getSessionId() {
   return _sessionId;
 }
 
-async function callRemoteTool(name, args) {
+async function callRemoteTool(name, args, _retried = false) {
   const sessionId = await getSessionId();
 
   const res = await fetch(`${WORKER_URL}/mcp`, {
@@ -396,11 +396,14 @@ async function callRemoteTool(name, args) {
     }),
   });
 
-  // 401 = token expired or revoked, re-authenticate and retry
+  // 401 = token expired or revoked, re-authenticate and retry once
   if (res.status === 401) {
+    if (_retried) {
+      return { content: [{ type: "text", text: "Authentication failed after retry. Please re-authenticate." }] };
+    }
     _cachedTokens = null;
     _sessionId = null;
-    return callRemoteTool(name, args);
+    return callRemoteTool(name, args, true);
   }
 
   const text = await res.text();
@@ -411,9 +414,9 @@ async function callRemoteTool(name, args) {
 
   if (json.error) {
     // Session expired — retry once with a fresh session
-    if (json.error.code === -32600 || json.error.code === -32001) {
+    if ((json.error.code === -32600 || json.error.code === -32001) && !_retried) {
       _sessionId = null;
-      return callRemoteTool(name, args);
+      return callRemoteTool(name, args, true);
     }
     return { content: [{ type: "text", text: JSON.stringify(json.error) }] };
   }

--- a/worker/src/oauth.ts
+++ b/worker/src/oauth.ts
@@ -29,8 +29,8 @@ export interface GitHubUserProps {
   githubLogin: string;
   /** GitHub access token (ghu_ prefix, 8h TTL) */
   githubAccessToken: string;
-  /** GitHub refresh token (ghr_ prefix, 6mo TTL) */
-  githubRefreshToken: string;
+  /** GitHub refresh token (ghr_ prefix, 6mo TTL). null when not provided. */
+  githubRefreshToken: string | null;
   /**
    * All account IDs (user + orgs) whose App installations the user can access.
    * Populated via GET /user/installations at OAuth time.
@@ -187,7 +187,7 @@ export async function handleGitHubCallback(
     githubUserId: user.id,
     githubLogin: user.login,
     githubAccessToken: tokenData.access_token,
-    githubRefreshToken: tokenData.refresh_token || "",
+    githubRefreshToken: tokenData.refresh_token || null,
     accessibleAccountIds,
   };
 


### PR DESCRIPTION
Refs #183

401エラーやセッション失効時の再帰リトライを1回に制限し、認証ループを防止。
空文字列リフレッシュトークンの保存も修正。