### PR TITLE
Fix concurrent token refresh race condition

### DIFF
--- a/mcp-server/server/index.js
+++ b/mcp-server/server/index.js
@@ -54,6 +54,7 @@ async function saveTokens(tokens) {
 }
 
 let _cachedTokens = null;
+let _refreshLock = null;
 
 // ── PKCE Utilities ───────────────────────────────────────────────────────────
 
@@ -344,11 +345,21 @@ async function getAccessToken() {
     }
 
     if (_cachedTokens.refresh_token) {
+      // Serialize concurrent refresh attempts to prevent race conditions.
+      // Without this lock, the WebSocket startup and the first tool call can
+      // both trigger refreshAccessToken() with the same refresh token
+      // simultaneously, causing the token file to end up with an orphaned
+      // refresh token that the Worker no longer recognizes.
+      if (!_refreshLock) {
+        _refreshLock = refreshAccessToken(_cachedTokens.refresh_token);
+      }
       try {
-        _cachedTokens = await refreshAccessToken(_cachedTokens.refresh_token);
+        _cachedTokens = await _refreshLock;
         return _cachedTokens.access_token;
       } catch (err) {
         console.error("[oauth] refresh failed, falling back to full OAuth flow:", err.message || err);
+      } finally {
+        _refreshLock = null;
       }
     } else {
       console.error("[oauth] no refresh_token available, requiring full OAuth flow");


### PR DESCRIPTION
## Summary

Refs #189

WebSocket起動と最初のツール呼び出しが同時に `refreshAccessToken()` を呼ぶ競合状態を修正。`_refreshLock` プロミスで同時リフレッシュを直列化し、Workerへのリクエストを1回に制限する。

- `_refreshLock` 変数を追加し、リフレッシュ中は同じプロミスを共有
- 2番目以降の呼び出し元は既存のリフレッシュプロミスを await
- `finally` ブロックでロックを確実に解放

## Test plan

- [ ] セッション再起動後、WebHook MCP の認証が自動的に成功することを確認
- [ ] 複数ターン後もトークンが有効であることを確認
- [ ] `~/.github-webhook-mcp/oauth-tokens.json` の refresh_token が一貫していることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)