### PR TITLE
docs: import Wiki nav and JA pages into docs/ (#193)

### DIFF
--- a/docs/0-requirements.ja.md
+++ b/docs/0-requirements.ja.md
@@ -1,0 +1,237 @@
+# 要件仕様
+
+## 目的
+
+GitHub Webhook イベントを Cloudflare Worker で受信・永続化し、MCP プロトコル経由で AI エージェントに提供する。
+エージェントが GitHub の状態変化をリアルタイムに検知し、自律的に対応できるようにする。
+
+## 前提
+
+- GitHub Webhook は Cloudflare Worker に直接到達する（ローカルサーバー不要）
+- イベントは Durable Object 内の SQLite に永続化される
+- AI エージェントは MCP stdio トランスポート（ローカルブリッジ）または Streamable HTTP（リモート）で接続する
+- ローカルブリッジは Worker にツール呼び出しをプロキシし、SSE でリアルタイム通知を中継する
+
+## アーキテクチャ
+
+```
+GitHub --POST--> Cloudflare Worker --> TenantRegistry DO
+                  | 署名検証                    | installation_id -> account_id
+                  | UUID 付与                    |
+                  |                             v
+                  |                    WebhookStore DO (SQLite) [per-tenant]
+                  |                             |
+                  +-- /mcp (Streamable HTTP)     +-- SSE real-time stream
+                  |    WebhookMcpAgent DO        +-- REST endpoints
+                  |    [per-tenant]                   /pending-status
+                  |    +-- tools -> WebhookStore       /pending-events
+                  |                                    /webhook-events
+                  +-- /events (SSE)                    /event
+                  |    +-- WebhookStore DO             /mark-processed
+                  |
+                  +-- /webhooks/github (POST)
+                       +-- TenantRegistry -> WebhookStore DO /ingest
+
+                          +-----------------------------+
+                          |  Local MCP Bridge (.mcpb)    |
+                          |  stdio <- Claude Desktop/CLI |
+                          |  -> proxy tool calls to /mcp |
+                          |  -> SSE listener -> channel  |
+                          +-----------------------------+
+```
+
+システムは四つのコンポーネントで構成される:
+
+1. **Cloudflare Worker** — Webhook 受信、署名検証、テナントルーティング
+2. **TenantRegistry Durable Object** — installation_id → account_id マッピング管理、テナント単位クォータ管理（単一インスタンス）
+3. **WebhookStore Durable Object** — SQLite によるイベント永続化、REST/SSE エンドポイント（テナント別インスタンス: `store-{accountId}`）
+4. **WebhookMcpAgent Durable Object** — MCP Streamable HTTP サーバー、ツール定義（テナント別インスタンス: `tenant-{accountId}`）
+
+ローカルブリッジ（mcp-server/）は Worker に対するプロキシであり、データを保持しない。
+
+## 機能要件
+
+### F1. Webhook 受信
+
+| ID | 要件 |
+|----|------|
+| F1.1 | `POST /webhooks/github` で GitHub Webhook ペイロードを受信する |
+| F1.2 | `X-Hub-Signature-256` ヘッダによる HMAC-SHA256 署名検証を行う |
+| F1.3 | 署名不一致時は HTTP 403 を返す |
+| F1.4 | シークレット未設定時は署名検証をスキップする |
+| F1.5 | テナント単位クォータ超過時は HTTP 429 を返す（installation イベントはクォータチェックをスキップ） |
+| F1.6 | 認証チェック順序: IP allowlist → per-IP rate limit → signature → tenant resolution → per-tenant quota → ingest |
+
+### F2. イベント永続化
+
+| ID | 要件 |
+|----|------|
+| F2.1 | イベントを UUID 付きで WebhookStore DO の SQLite に保存する |
+| F2.2 | 各イベントは id, type, payload, received_at, processed フィールドを持つ |
+| F2.3 | trigger_status, last_triggered_at フィールドを保持する（将来の trigger 機能用） |
+
+**イベント構造:**
+
+```json
+{
+  "id": "uuid",
+  "type": "issues",
+  "payload": {},
+  "received_at": "ISO8601",
+  "processed": false,
+  "trigger_status": null,
+  "last_triggered_at": null
+}
+```
+
+### F3. MCP ツール
+
+WebhookMcpAgent DO が以下のツールセットを提供する。ローカルブリッジはこれをプロキシする。
+
+| ID | ツール名 | 引数 | 戻り値 | 要件 |
+|----|---------|------|--------|------|
+| F3.1 | `get_pending_status` | なし | pending_count, latest_received_at, types | 未処理イベントの軽量スナップショットを返す |
+| F3.2 | `list_pending_events` | limit (1-100, default 20) | サマリー配列 | 未処理イベントのメタデータ一覧を返す（ペイロード含まず） |
+| F3.3 | `get_event` | event_id | 完全イベント or error | UUID 指定で完全なペイロードを返す |
+| F3.4 | `get_webhook_events` | limit (1-100, default 20) | 未処理イベント配列 | 未処理イベントをフルペイロード付きで返す |
+| F3.5 | `mark_processed` | event_id | success, event_id | イベントを処理済みにマークする |
+
+**イベントサマリー構造:**
+
+```json
+{
+  "id": "uuid",
+  "type": "issues",
+  "received_at": "ISO8601",
+  "processed": false,
+  "trigger_status": null,
+  "last_triggered_at": null,
+  "action": "opened",
+  "repo": "owner/repo",
+  "sender": "username",
+  "number": 123,
+  "title": "Issue title",
+  "url": "https://github.com/..."
+}
+```
+
+### F4. SSE リアルタイムイベント配信
+
+| ID | 要件 |
+|----|------|
+| F4.1 | `GET /events` で SSE ストリームを提供する |
+| F4.2 | Webhook ingest 時に接続中の全 SSE クライアントにイベントサマリーをブロードキャストする |
+| F4.3 | 30 秒間隔でハートビートを送信する |
+| F4.4 | クライアント切断時にクリーンアップする |
+
+### F5. チャンネル通知（ローカルブリッジ）
+
+| ID | 要件 |
+|----|------|
+| F5.1 | ローカルブリッジが Claude Code の `claude/channel` experimental capability を宣言する |
+| F5.2 | Worker の SSE エンドポイントに接続し、新規イベント検出時に `notifications/claude/channel` を送信する |
+| F5.3 | 通知内容はイベントサマリー（type, repo, action, title, sender）を含む |
+| F5.4 | `meta` フィールドに `chat_id`, `message_id`, `user`, `ts` を付与する |
+| F5.5 | `WEBHOOK_CHANNEL=0` 環境変数でチャンネル通知を無効化できる（デフォルト: 有効） |
+| F5.6 | チャンネル通知は one-way（読み取り専用）で、reply tool は提供しない |
+
+### F6. 推奨ポーリングフロー
+
+| ステップ | 操作 |
+|---------|------|
+| 1 | `get_pending_status()` を 60 秒間隔でポーリング |
+| 2 | `pending_count > 0` なら `list_pending_events()` でサマリー取得 |
+| 3 | フルペイロードが必要なイベントのみ `get_event(event_id)` で取得 |
+| 4 | 処理完了後 `mark_processed(event_id)` でマーク |
+
+## 非機能要件
+
+### N1. セキュリティ
+
+| ID | 要件 |
+|----|------|
+| N1.1 | Webhook シークレットは Cloudflare Worker の Secret（`GITHUB_WEBHOOK_SECRET`）で管理する |
+| N1.2 | HMAC-SHA256 による署名検証でスプーフィングを防止する |
+| N1.3 | ローカルブリッジは stdio トランスポートを使用し、ネットワーク露出しない |
+| N1.4 | Webhook エンドポイントは多層防御で DDoS/課金攻撃を防止する: IP allowlist → per-IP rate limit → signature → tenant resolution → per-tenant quota |
+| N1.5 | GitHub IP allowlist（api.github.com/meta の hooks フィールド）で非 GitHub IP を最外層でブロックする（github-ip.ts） |
+| N1.6 | Per-IP rate limit はインメモリ sliding window で Worker isolate 内に実装する（rate-limit.ts） |
+| N1.7 | Per-tenant quota は TenantRegistry DO で atomic check-and-increment により管理し、単一テナントの無制限ストレージ消費を防止する |
+| N1.8 | Cloudflare WAF カスタムルールによる外部 IP ブロックを推奨する（Worker 到達前にブロックし CPU 課金を削減） |
+
+### N2. 構成
+
+| ID | 項目 | ソース | デフォルト |
+|----|------|--------|-----------|
+| N2.1 | Worker URL | `WEBHOOK_WORKER_URL` 環境変数 | なし（必須） |
+| N2.2 | シークレット | Cloudflare Secret `GITHUB_WEBHOOK_SECRET` | なし（検証スキップ） |
+| N2.3 | チャンネル通知の有効/無効 | `WEBHOOK_CHANNEL` | 有効（`0` で無効） |
+| N2.4 | カスタムドメイン | `github-webhook.smgjp.com` | Cloudflare Worker のカスタムドメインとして設定済み |
+| N2.5 | 認証方式 | Worker 自前認証 | Cloudflare Access は使用しない。Worker が webhook secret + OAuth で認証を処理する |
+| N2.6 | プレビューインスタンス | `preview` 環境 | 本番と同一構成の検証用インスタンス |
+
+### N3. 制約
+
+| ID | 制約 |
+|----|------|
+| N3.1 | WebhookStore / McpAgent DO はテナント別インスタンス（`idFromName("store-{accountId}")` / `getAgentByName("tenant-{accountId}")`）で動作する。TenantRegistry DO は単一インスタンスで全テナントの installation-account マッピングを管理する |
+| N3.2 | SSE 接続は DO のメモリ内で管理される（DO eviction 時に切断） |
+| N3.3 | ローカルブリッジはツール呼び出しごとに Worker セッションを再利用する（セッション失効時は自動リトライ） |
+| N3.4 | OAuth コールバック時に `GET /user/installations` で取得した accessible_account_ids（ユーザー + org）を GitHubUserProps に保存し、McpAgent が複数 store を並列クエリして結果をマージする。これにより org インストールのイベントもメンバーの MCP セッションから参照できる |
+
+## CI/CD
+
+### テスト（CI）
+
+| トリガー | ジョブ | 内容 |
+|---------|--------|------|
+| PR to main / push to main | test | Node.js syntax check |
+
+### リリース（CD）
+
+| トリガー | ジョブ | 内容 |
+|---------|--------|------|
+| `v*` タグ push | build-mcpb | `mcpb pack` で .mcpb 生成 |
+| `v*` タグ push | release | GitHub Release 作成 + .mcpb 添付 |
+| `v*` タグ push | npm-publish | npm レジストリに公開 |
+
+リリースフロー:
+1. `v*` タグを push する
+2. CD が自動実行: .mcpb 生成 → release 作成 → .mcpb 添付 → npm publish
+3. npm publish 時にタグ名から自動でバージョンを同期する（package.json の手動更新不要）
+4. プレリリースタグ（`-` を含む）は `next` dist-tag で公開、正式リリースは `latest` で公開
+
+## 依存関係
+
+### Cloudflare Worker
+
+| パッケージ | 用途 |
+|-----------|------|
+| agents | Cloudflare Agents SDK (McpAgent) |
+| @modelcontextprotocol/sdk | MCP SDK |
+| zod | スキーマバリデーション |
+
+### ローカルブリッジ (mcp-server/)
+
+| パッケージ | 用途 |
+|-----------|------|
+| @modelcontextprotocol/sdk | MCP SDK（`Server` クラス直接使用） |
+| eventsource | SSE クライアント |
+
+Node.js >= 18.0.0 が必要。
+
+## ファイル構成
+
+| パス | 用途 |
+|-----|------|
+| `worker/src/index.ts` | Cloudflare Worker エントリポイント |
+| `worker/src/agent.ts` | WebhookMcpAgent DO（MCP ツール定義、テナント別インスタンス） |
+| `worker/src/store.ts` | WebhookStore DO（SQLite + SSE、テナント別インスタンス） |
+| `worker/src/tenant.ts` | TenantRegistry DO（installation-account マッピング、クォータ管理） |
+| `worker/wrangler.toml` | Worker デプロイ設定 |
+| `shared/src/types.ts` | 共有型定義 |
+| `shared/src/summarize.ts` | イベントサマリー生成 |
+| `local-mcp/src/index.ts` | ローカルブリッジ（TypeScript、開発用） |
+| `mcp-server/server/index.js` | ローカルブリッジ（JS、.mcpb 配布用） |
+| `mcp-server/manifest.json` | MCPB マニフェスト |
+| `mcp-server/package.json` | npm パッケージ定義 |

--- a/docs/Home.md
+++ b/docs/Home.md
@@ -1,0 +1,89 @@
+# github-webhook-mcp
+
+Cloudflare Worker + Durable Object による、リアルタイム GitHub Webhook 通知を AI エージェントに MCP 経由で提供します。
+
+## アーキテクチャ
+
+```
+GitHub --POST--> Cloudflare Worker --> Durable Object (SQLite)
+                                           |
+                                           +-- MCP tools (Streamable HTTP)
+                                           +-- SSE real-time stream
+                                           |
+                          +----------------+
+                          |
+     Desktop / Codex: .mcpb local bridge --> polling via MCP tools
+     Claude Code CLI: .mcpb local bridge --> SSE -> channel notifications
+```
+
+- **Cloudflare Worker** が GitHub Webhook を受信し、署名を検証し、Durable Object の SQLite にイベントを保存します。
+- **ローカル MCP ブリッジ** (.mcpb) は Worker へのツール呼び出しをプロキシし、オプションで SSE を使ったリアルタイムチャンネル通知をリッスンします。
+- ローカル Webhook レシーバーやトンネルは不要です。
+
+## はじめに
+
+### 1. GitHub App のインストール
+
+**GitHub Webhook MCP** アプリを GitHub Organization またはアカウントにインストール:
+
+1. [GitHub App インストールページ](https://github.com/apps/liplus-webhook-mcp) にアクセス
+2. インストール先の Organization またはアカウントを選択
+3. アクセスを許可するリポジトリを選択（または全リポジトリ）
+4. 要求されたパーミッションを承認
+
+> **注意:** アップデート後にアプリが新しいパーミッションを要求した場合、GitHub 通知またはアプリのインストール設定で承認する必要があります。パーミッションが承認されるまで Webhook は配信されません。
+
+> **重要:** 同じエンドポイントに別途リポジトリ Webhook を作成しないでください。GitHub App がすべての Webhook 配信を処理します。
+
+### 2. MCP クライアントの設定
+
+[[インストールガイド|installation.ja]] に進んで、AI アシスタントを Webhook サービスに接続してください。
+
+## インストール
+
+[[インストールガイド|installation.ja]] で完全なセットアップガイドを参照:
+
+- **クイックスタート** — プレビューインスタンスを使用
+- **MCP クライアント設定** — Claude Desktop、Claude Code CLI、Codex 向け
+- **セルフホスティングガイド** — Cloudflare Workers デプロイ
+
+## MCP ツール
+
+| ツール | 説明 |
+|--------|------|
+| `get_pending_status` | 未処理イベント数のタイプ別軽量スナップショット |
+| `list_pending_events` | 未処理イベントのサマリー（フルペイロードなし） |
+| `get_event` | ID 指定で単一イベントのフルペイロード取得 |
+| `get_webhook_events` | 全未処理イベントのフルペイロード取得 |
+| `mark_processed` | イベントを処理済みにマーク |
+
+## モノレポ構成
+
+```
+worker/       — Cloudflare Worker + Durable Objects
+local-mcp/    — ローカル stdio MCP ブリッジ（TypeScript、開発用）
+mcp-server/   — Claude Desktop 用 .mcpb パッケージ
+shared/       — 共有型・ユーティリティ
+```
+
+## プライバシーポリシー
+
+イベントは Cloudflare Durable Object（エッジストレージ）に保存されます。ローカル MCP ブリッジは Worker へのツール呼び出しをプロキシするのみで、イベントデータをローカルに保存しません。
+
+- 拡張機能プライバシーポリシー: https://smgjp.com/privacy-policy-github-webhook-mcp/
+
+## サポート
+
+- GitHub Issues: https://github.com/Liplus-Project/github-webhook-mcp/issues
+- [[要件仕様|0-requirements.ja]]
+
+## 関連プロジェクト
+
+- [Liplus-Project/liplus-language](https://github.com/Liplus-Project/liplus-language) — Li+ 言語仕様
+
+---
+
+## Pages
+
+- Installation: [[EN|installation]] / [[JA|installation.ja]]
+- Requirements: [[EN|0-requirements]] / [[JA|0-requirements.ja]]

--- a/docs/_Footer.md
+++ b/docs/_Footer.md
@@ -1,0 +1,1 @@
+[GitHub](https://github.com/Liplus-Project/github-webhook-mcp) | [npm](https://www.npmjs.com/package/github-webhook-mcp) | [Discussions](https://github.com/Liplus-Project/github-webhook-mcp/discussions)

--- a/docs/_Sidebar.md
+++ b/docs/_Sidebar.md
@@ -1,0 +1,5 @@
+**github-webhook-mcp**
+
+- [[Home]]
+- Installation: [[EN|installation]] / [[JA|installation.ja]]
+- Requirements: [[EN|0-requirements]] / [[JA|0-requirements.ja]]

--- a/docs/installation.ja.md
+++ b/docs/installation.ja.md
@@ -1,0 +1,250 @@
+# インストール
+
+## クイックスタート
+
+プレビューインスタンスを使えばすぐに試せます:
+
+1. [GitHub Webhook MCP](https://github.com/apps/liplus-webhook-mcp) アプリを GitHub アカウントまたは Organization にインストール
+2. MCP クライアントを設定（下記 [MCP クライアント設定](#mcp-クライアント設定) 参照）:
+   - Worker URL: `https://github-webhook.smgjp.com`
+3. Webhook 通知の受信を開始
+
+> **注意:** `github-webhook.smgjp.com` のプレビューインスタンスは評価目的で提供されています。SLA はなく、予告なく変更・停止される場合があります。本番利用の場合は [セルフホスティングガイド](#セルフホスティングガイド) をご覧ください。
+
+## MCP クライアント設定
+
+> **前提:** Node.js 18+ が必要です（ローカル MCP ブリッジの実行に使用）。
+
+### Claude Desktop — デスクトップ拡張 (.mcpb)
+
+[Releases](https://github.com/Liplus-Project/github-webhook-mcp/releases) から `github-webhook-mcp.mcpb` をダウンロード:
+
+1. Claude Desktop → **設定** → **拡張機能** → **拡張機能をインストール...**
+2. `.mcpb` ファイルを選択
+3. Worker URL を入力（例: `https://github-webhook-mcp.example.workers.dev`）
+
+### Claude Code CLI — npx
+
+```json
+{
+  "mcpServers": {
+    "github-webhook-mcp": {
+      "command": "npx",
+      "args": ["github-webhook-mcp"],
+      "env": {
+        "WEBHOOK_WORKER_URL": "https://github-webhook-mcp.example.workers.dev",
+        "WEBHOOK_CHANNEL": "1"
+      }
+    }
+  }
+}
+```
+
+`WEBHOOK_CHANNEL=1` でリアルタイムチャンネル通知を有効化（Claude Code CLI のみ）。
+
+### Codex — config.toml
+
+```toml
+[mcp.github-webhook-mcp]
+command = "npx"
+args = ["github-webhook-mcp"]
+
+[mcp.github-webhook-mcp.env]
+WEBHOOK_WORKER_URL = "https://github-webhook-mcp.example.workers.dev"
+WEBHOOK_CHANNEL = "0"
+```
+
+## セルフホスティングガイド
+
+独自の Cloudflare Worker インスタンスをデプロイして、Webhook 処理とデータを完全に管理できます。
+
+### 前提条件
+
+| 要件 | 用途 |
+|------|------|
+| **Cloudflare アカウント** | Worker、Durable Object、KV のホスティング |
+| **GitHub アカウント** | リポジトリの Fork と GitHub App の作成 |
+
+### 1. リポジトリの Fork
+
+[github-webhook-mcp](https://github.com/Liplus-Project/github-webhook-mcp) リポジトリを自分の GitHub アカウントに Fork してください。
+
+### 2. Cloudflare Workers & Pages でプロジェクト作成
+
+Cloudflare ダッシュボードから Worker を作成し、GitHub リポジトリと接続します:
+
+1. [Cloudflare ダッシュボード](https://dash.cloudflare.com/) にログイン
+2. **Workers & Pages** → **Create** → **Import a repository** を選択
+3. GitHub アカウントを接続し、Fork したリポジトリを選択
+4. ビルド設定を構成:
+
+| 項目 | 値 |
+|------|-----|
+| **Worker name** | `github-webhook-mcp`（`wrangler.toml` の `name` と一致させること） |
+| **Root directory** | `worker`（モノレポのため、Worker ソースのあるディレクトリを指定） |
+| **Build command** | `npm install && npx wrangler deploy` |
+
+5. **Save and Deploy** を選択
+
+> **重要:** Worker 名は `wrangler.toml` の `name` フィールドと一致させる必要があります。不一致の場合ビルドが失敗します。
+
+デプロイが成功すると Worker URL が表示されます（例: `https://github-webhook-mcp.example.workers.dev`）。この URL を以降の手順で使用します。
+
+接続後は、リポジトリへの push で自動デプロイが行われます。
+
+デプロイにより以下が自動的に作成されます:
+- **WebhookMcpAgent** Durable Object — MCP ツール提供（テナント別）
+- **WebhookStore** Durable Object — イベント永続化（テナント別）
+- **TenantRegistry** Durable Object — テナント管理（単一インスタンス）
+- SQLite マイグレーションが自動適用
+
+### 3. KV Namespace の作成
+
+OAuth トークンの保存に使用する KV Namespace を作成します。
+Cloudflare ダッシュボードから作成する方法と、wrangler CLI で作成する方法があります。
+
+**ダッシュボードの場合:**
+
+1. **Workers & Pages** → **KV** → **Create a namespace**
+2. Namespace 名に `OAUTH_KV` と入力して作成
+3. 作成後に表示される Namespace ID をメモ
+
+**wrangler CLI の場合:**
+
+```bash
+cd worker
+npx wrangler kv namespace create OAUTH_KV
+```
+
+いずれの方法でも、出力される KV Namespace ID を `wrangler.toml` の `PLACEHOLDER_KV_ID` に設定します:
+
+```toml
+[[kv_namespaces]]
+binding = "OAUTH_KV"
+id = "<ここに KV Namespace ID を貼り付け>"
+```
+
+変更をコミット・push すると、自動デプロイで KV バインディングが反映されます。
+
+### 4. GitHub App の作成と設定
+
+**GitHub Settings** → **Developer settings** → **GitHub Apps** → **New GitHub App** で新規作成:
+
+#### 基本設定
+
+| 項目 | 値 |
+|------|-----|
+| **App name** | 任意（例: `My Webhook MCP`） |
+| **Homepage URL** | Worker URL または リポジトリ URL |
+| **Webhook URL** | `https://<your-worker>/webhooks/github` |
+| **Webhook secret** | 強力なランダム文字列（ステップ 5 で同じ値を設定） |
+| **Content type** | `application/json`（必須） |
+
+#### OAuth 設定（MCP リモート接続に必要）
+
+| 項目 | 値 |
+|------|-----|
+| **Callback URL** | `https://<your-worker>/oauth/callback` |
+
+Client ID と Client secret を生成・メモしてください（ステップ 5 で使用）。
+
+#### パーミッション
+
+受信したいイベントに応じて設定:
+
+| カテゴリ | パーミッション | 用途 |
+|---------|-------------|------|
+| **Issues** | Read | Issue イベント |
+| **Pull requests** | Read | PR イベント |
+| **Contents** | Read | Push イベント |
+| **Checks** | Read | Check run イベント |
+| **Actions** | Read | Workflow run イベント |
+| **Discussions** | Read | Discussion イベント |
+
+#### イベント購読
+
+監視したいイベントにチェック:
+- Issues / Issue comment
+- Pull request / Pull request review / Pull request review comment / Pull request review thread
+- Push
+- Check run / Workflow run
+- Discussion / Discussion comment
+
+#### インストール
+
+作成後、アプリをアカウントまたは Organization にインストールし、監視するリポジトリを選択してください。
+
+> **重要:** 同じエンドポイントに別途リポジトリ Webhook を作成しないでください。GitHub App がすべての Webhook 配信を処理します。リポジトリ Webhook を追加すると重複や不正なリクエストが発生します。
+
+### 5. シークレットの設定
+
+3 つのシークレットを Cloudflare に登録。ダッシュボードの **Workers & Pages** → Worker → **Settings** → **Variables and Secrets** から設定するか、wrangler CLI で設定します:
+
+```bash
+# GitHub App の Webhook secret
+npx wrangler secret put GITHUB_WEBHOOK_SECRET
+
+# GitHub App の OAuth Client ID
+npx wrangler secret put GITHUB_CLIENT_ID
+
+# GitHub App の OAuth Client Secret
+npx wrangler secret put GITHUB_CLIENT_SECRET
+```
+
+各コマンドでプロンプトが表示されるので、対応する値を入力してください。
+
+### 6. カスタムドメイン（オプション）
+
+デフォルトの `*.workers.dev` URL の代わりにカスタムドメインを使用するには:
+
+1. Cloudflare ダッシュボード → **Workers & Pages** → Worker → **Settings** → **Domains & Routes**
+2. カスタムドメインを追加（例: `github-webhook.example.com`）
+3. GitHub App の Webhook URL と Callback URL をカスタムドメインに更新
+4. MCP クライアント設定の `WEBHOOK_WORKER_URL` を更新
+
+### 7. WAF ルール（推奨）
+
+Cloudflare WAF でセキュリティルールを設定すると、Worker 到達前に不正リクエストをブロックでき、CPU 課金を削減できます。
+
+#### GitHub IP 制限
+
+Webhook エンドポイントへのアクセスを GitHub の IP 範囲に制限:
+
+- **対象パス:** `/webhooks/github`
+- **条件:** `(http.request.uri.path eq "/webhooks/github") and not (ip.src in { 140.82.112.0/20 185.199.108.0/22 192.30.252.0/22 143.55.64.0/20 })`
+- **アクション:** Block
+
+> **注意:** GitHub の IP 範囲は変更される場合があります。最新の情報は `https://api.github.com/meta` の `hooks` フィールドで確認してください。
+
+#### レートリミット
+
+- **Webhook:** 300 req/min per IP（`/webhooks/github`）
+- **API:** 120 req/min per IP（`/mcp`, `/events`）
+
+### 8. チャンネル通知（オプション）
+
+ローカル MCP ブリッジは Claude Code の `claude/channel` 機能をサポートしています。有効にすると、新しい Webhook イベントが SSE 経由でリアルタイムにセッションにプッシュされます。Claude Code CLI でのみ利用可能です。
+
+MCP クライアント設定で `WEBHOOK_CHANNEL=1` を設定し（上記 [Claude Code CLI](#claude-code-cli--npx) 参照）、チャンネルをロード:
+
+```bash
+claude --dangerously-load-development-channels server:github-webhook-mcp
+```
+
+### デプロイの確認
+
+デプロイ後、以下で動作確認できます:
+
+1. **Webhook 受信テスト:** GitHub App の設定ページ → **Advanced** → **Recent Deliveries** で配信状況を確認
+2. **MCP 接続テスト:** MCP クライアントから `get_pending_status` ツールを呼び出して応答を確認
+3. **SSE テスト:** `curl -N https://<your-worker>/events` でストリーム接続を確認
+
+### トラブルシューティング
+
+| 症状 | 原因と対処 |
+|------|-----------|
+| Webhook が 403 を返す | `GITHUB_WEBHOOK_SECRET` が GitHub App の設定と一致していない。両方の値を確認 |
+| Webhook が 429 を返す | テナントクォータ（デフォルト 10,000 イベント）を超過。古いイベントを `mark_processed` で処理 |
+| OAuth ログインが失敗する | `GITHUB_CLIENT_ID` と `GITHUB_CLIENT_SECRET` が正しいか確認。Callback URL が一致しているか確認 |
+| KV エラーが出る | `wrangler.toml` の KV ID が `wrangler kv namespace create` の出力と一致しているか確認 |
+| MCP ツールが応答しない | Worker がデプロイされているか `wrangler tail` でログを確認 |


### PR DESCRIPTION
Closes #193

GitHub Wiki にしか存在していなかった navigation 3 ファイル（Home / _Sidebar / _Footer）と
日本語翻訳 2 ファイル（Requirements-ja / Installation-ja）を `docs/` 配下に取り込み、
Wiki sync の "Wiki must be a complete mirror of docs/" 不変式を満たす。
ja ファイルは docs/ 命名規約に合わせて `0-requirements.ja.md` / `installation.ja.md` にリネーム。
Home.md と _Sidebar.md の `[[…]]` link 参照を新 docs 命名に書き換え、本文と ja content は不変。

## 変更ファイル

- `docs/Home.md` (新規) — link 参照を新命名へ更新
- `docs/_Sidebar.md` (新規) — link 参照を新命名へ更新
- `docs/_Footer.md` (新規) — そのまま取り込み
- `docs/0-requirements.ja.md` (新規) — Wiki Requirements-ja.md をリネーム取り込み
- `docs/installation.ja.md` (新規) — Wiki Installation-ja.md をリネーム取り込み

## link 書き換えルール適用

- `[[Installation-ja]]` → `[[installation.ja]]`
- `[[Requirements-ja]]` → `[[0-requirements.ja]]`
- `[[Installation]]` → `[[installation]]`
- `[[Requirements]]` → `[[0-requirements]]`
- `[[表示テキスト|旧名]]` 形式の右辺もすべて新命名へ

姉妹プロジェクト github-rag-mcp v0.7.1 (PR #94) と同じ構造。
本 PR merge 後、v0.10.7 release サイクルで wiki sync を再実行する。