### PR TITLE
chore(wrangler): sync observability config from Cloudflare dashboard

### DIFF
--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -65,3 +65,18 @@ id = "67611ab57f734f1c9a0b5d5a96f65e78"
 #   Set up "Usage Based Billing" notifications for Workers requests
 #   to detect billing anomalies early.
 # ────────────────────────────────────────────────────────────────────
+
+[observability]
+enabled = false
+head_sampling_rate = 1
+
+[observability.logs]
+enabled = true
+head_sampling_rate = 1
+persist = true
+invocation_logs = true
+
+[observability.traces]
+enabled = false
+persist = true
+head_sampling_rate = 1


### PR DESCRIPTION
## 目的

Cloudflare Workers ダッシュボードで有効化した Observability (Workers Logs) の設定を `worker/wrangler.toml` に同期する。ダッシュボード側にしか反映されていない状態は、次回 `wrangler deploy` で silent に revert されるリスクがあるため、dashboard が提示した TOML を末尾に追記して固定化する。

## 変更内容

`worker/wrangler.toml` 末尾に以下 3 セクションを追記のみ:

- `[observability]` (enabled=false, head_sampling_rate=1)
- `[observability.logs]` (enabled=true, persist=true, invocation_logs=true)
- `[observability.traces]` (enabled=false, persist=true)

既存設定は変更なし。dashboard 提示の TOML と完全一致。

## 影響スコープ

patch (config sync のみ、user/system observable behavior 変化なし)。

Closes #213