### PR TITLE
docs(mcp): recommend alwaysLoad: true for Claude Code v2.1.121+

### DIFF
--- a/docs/installation.ja.md
+++ b/docs/installation.ja.md
@@ -66,6 +66,7 @@ A browser window should have opened automatically. Sign in on GitHub, then retry
     "github-webhook-mcp": {
       "command": "npx",
       "args": ["github-webhook-mcp"],
+      "alwaysLoad": true,
       "env": {
         "WEBHOOK_WORKER_URL": "https://github-webhook-mcp.example.workers.dev",
         "WEBHOOK_CHANNEL": "1"
@@ -76,6 +77,8 @@ A browser window should have opened automatically. Sign in on GitHub, then retry
 ```
 
 `WEBHOOK_CHANNEL=1` でリアルタイムチャンネル通知を有効化（Claude Code CLI のみ）。
+
+`alwaysLoad: true` は Claude Code v2.1.121 以降で利用可能。本サーバーのツールを tool-search の deferral 対象から外し、毎ターン即座に利用可能にします（UserPromptSubmit hook 経由で毎ターン呼ばれるため推奨）。
 
 ### Codex — config.toml
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -66,6 +66,7 @@ A browser window should have opened automatically. Sign in on GitHub, then retry
     "github-webhook-mcp": {
       "command": "npx",
       "args": ["github-webhook-mcp"],
+      "alwaysLoad": true,
       "env": {
         "WEBHOOK_WORKER_URL": "https://github-webhook-mcp.example.workers.dev",
         "WEBHOOK_CHANNEL": "1"
@@ -74,6 +75,8 @@ A browser window should have opened automatically. Sign in on GitHub, then retry
   }
 }
 ```
+
+`alwaysLoad: true` requires Claude Code v2.1.121 or later. It exempts this server's tools from tool-search deferral so they remain immediately callable every turn (recommended because the server is invoked every turn via the UserPromptSubmit hook).
 
 `WEBHOOK_CHANNEL=1` でリアルタイムチャンネル通知を有効化（Claude Code CLI のみ）。
 

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -62,7 +62,8 @@ Add the server to your MCP client configuration. Example for Claude Desktop (`cl
   "mcpServers": {
     "github-webhook": {
       "command": "npx",
-      "args": ["-y", "github-webhook-mcp"]
+      "args": ["-y", "github-webhook-mcp"],
+      "alwaysLoad": true
     }
   }
 }
@@ -76,6 +77,7 @@ To target a self-hosted Worker, set the `WEBHOOK_WORKER_URL` environment variabl
     "github-webhook": {
       "command": "npx",
       "args": ["-y", "github-webhook-mcp"],
+      "alwaysLoad": true,
       "env": {
         "WEBHOOK_WORKER_URL": "https://your-worker.example.workers.dev"
       }
@@ -83,6 +85,8 @@ To target a self-hosted Worker, set the `WEBHOOK_WORKER_URL` environment variabl
   }
 }
 ```
+
+`alwaysLoad: true` requires Claude Code v2.1.121 or later. It exempts this server's tools from tool-search deferral so they remain immediately callable every turn (recommended because the server is invoked every turn via the UserPromptSubmit hook).
 
 ### Codex (`config.toml`)
 


### PR DESCRIPTION
## Summary

- `.mcp.json` の推奨スニペット（`docs/installation.md` / `docs/installation.ja.md` / `mcp-server/README.md`）に `"alwaysLoad": true` を追加。
- 配置位置は `args` の直後・`env` の直前で統一。
- Claude Code v2.1.121 以降で利用可能である旨と、tool-search deferral を回避できる利点を近接プロセに追記。

## Background

Claude Code v2.1.121 (2026-04-28 release) で MCP server config に `alwaysLoad` オプションが追加された。`true` の場合、そのサーバーのツールは tool-search の deferral 対象から外れ、毎ターン即座に呼び出せる状態が保たれる。

`github-webhook-mcp` は UserPromptSubmit hook 経由で毎ターン参照されるため、deferral がかかると無駄な round trip が増える。`alwaysLoad: true` を推奨設定として明示しておく。

## Test plan

- [x] 3 ファイルの JSON スニペット差分を目視確認
- [x] `alwaysLoad` キーが既存設定と衝突していないことを確認（既存ファイルに `alwaysLoad` 言及なし）
- [ ] CI green
- [ ] Self-review pass

Closes #217