### PR TITLE
test(worker): verifyGitHubSignature HMAC unit tests (patch)

### DIFF
--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -29,6 +29,7 @@ import {
 } from "./oauth.js";
 import { isGitHubWebhookIP } from "./github-ip.js";
 import { checkWebhookRateLimit, checkApiRateLimit, checkTenantQuota, rateLimitResponse } from "./rate-limit.js";
+import { verifyGitHubSignature } from "./signature.js";
 
 export { WebhookMcpAgent, WebhookStore, TenantRegistry };
 
@@ -37,26 +38,6 @@ interface Env extends OAuthEnv {
   WEBHOOK_STORE: DurableObjectNamespace;
   TENANT_REGISTRY: DurableObjectNamespace;
   GITHUB_WEBHOOK_SECRET?: string;
-}
-
-async function verifyGitHubSignature(
-  secret: string,
-  body: string,
-  signature: string,
-): Promise<boolean> {
-  const encoder = new TextEncoder();
-  const key = await crypto.subtle.importKey(
-    "raw",
-    encoder.encode(secret),
-    { name: "HMAC", hash: "SHA-256" },
-    false,
-    ["sign"],
-  );
-  const sig = await crypto.subtle.sign("HMAC", key, encoder.encode(body));
-  const expected = "sha256=" + Array.from(new Uint8Array(sig))
-    .map((b) => b.toString(16).padStart(2, "0"))
-    .join("");
-  return expected === signature;
 }
 
 /**

--- a/worker/src/signature.ts
+++ b/worker/src/signature.ts
@@ -1,0 +1,29 @@
+/**
+ * GitHub webhook signature verification (#227).
+ *
+ * Verifies GitHub's `X-Hub-Signature-256` header — an HMAC-SHA256 digest of the
+ * raw request body keyed with the shared webhook secret — using Web Crypto
+ * (`crypto.subtle`). Returns true only when the recomputed `sha256=<hex>` digest
+ * exactly matches the supplied signature string; any mismatch (tampered body,
+ * wrong secret, malformed signature) returns false. This is the webhook trust
+ * boundary: it proves both authentic GitHub origin and body integrity.
+ */
+export async function verifyGitHubSignature(
+  secret: string,
+  body: string,
+  signature: string,
+): Promise<boolean> {
+  const encoder = new TextEncoder();
+  const key = await crypto.subtle.importKey(
+    "raw",
+    encoder.encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const sig = await crypto.subtle.sign("HMAC", key, encoder.encode(body));
+  const expected = "sha256=" + Array.from(new Uint8Array(sig))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+  return expected === signature;
+}

--- a/worker/test/signature.test.ts
+++ b/worker/test/signature.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Unit tests for worker/src/signature.ts (#227).
+ *
+ * verifyGitHubSignature is the webhook trust boundary: it must accept a body
+ * signed with the matching secret and reject every other case. The expected
+ * valid signature is generated INDEPENDENTLY via Node's node:crypto
+ * (createHmac → "sha256=" + hex digest), giving an oracle that does not call
+ * the function under test. crypto.subtle exists in Node 20+, so this runs as a
+ * pure tsx --test unit test (no Miniflare).
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { createHmac } from "node:crypto";
+
+import { verifyGitHubSignature } from "../src/signature.js";
+
+const SECRET = "s3cr3t-webhook-key";
+const BODY = JSON.stringify({ action: "opened", number: 42 });
+
+/** Independent oracle: GitHub's X-Hub-Signature-256 = "sha256=" + HMAC-SHA256 hex. */
+function sign(secret: string, body: string): string {
+  return "sha256=" + createHmac("sha256", secret).update(body).digest("hex");
+}
+
+// ── Valid case ───────────────────────────────────────────────────────
+
+test("accepts a signature generated with the same secret and body", async () => {
+  const signature = sign(SECRET, BODY);
+  assert.equal(await verifyGitHubSignature(SECRET, BODY, signature), true);
+});
+
+// ── Tampered body ────────────────────────────────────────────────────
+
+test("rejects when the body was tampered after signing", async () => {
+  // Sign body A, verify against body B.
+  const signature = sign(SECRET, BODY);
+  const tamperedBody = JSON.stringify({ action: "opened", number: 9999 });
+  assert.equal(await verifyGitHubSignature(SECRET, tamperedBody, signature), false);
+});
+
+// ── Wrong secret ─────────────────────────────────────────────────────
+
+test("rejects when verified with a different secret", async () => {
+  const signature = sign(SECRET, BODY);
+  assert.equal(await verifyGitHubSignature("wrong-secret", BODY, signature), false);
+});
+
+// ── Malformed signature formats ──────────────────────────────────────
+
+test("rejects an empty signature string", async () => {
+  assert.equal(await verifyGitHubSignature(SECRET, BODY, ""), false);
+});
+
+test("rejects a signature without the sha256= prefix", async () => {
+  // Same hex digest but missing the "sha256=" prefix.
+  const hexOnly = createHmac("sha256", SECRET).update(BODY).digest("hex");
+  assert.equal(await verifyGitHubSignature(SECRET, BODY, hexOnly), false);
+});
+
+test("rejects a sha256=-prefixed hex of the wrong length", async () => {
+  // Truncated digest (valid prefix, too few hex chars).
+  const shortHex = createHmac("sha256", SECRET).update(BODY).digest("hex").slice(0, 32);
+  assert.equal(await verifyGitHubSignature(SECRET, BODY, "sha256=" + shortHex), false);
+});


### PR DESCRIPTION
Closes #227

## 概要

webhook 受け口の HMAC-SHA256 署名検証 `verifyGitHubSignature` をテストでカバーする。`index.ts` の module-private 関数を `worker/src/signature.ts` に抽出（`export` 付き・**挙動は不変**）し、`index.ts` は import に差し替えた。`index.ts` は agent / oauth / store のフルグラフを import するため関数を直接 import できず、純 HMAC ロジックを切り出すことで軽量 unit test に載せられるようにした。

## 影響スコープ

**patch**（挙動不変）。署名検証ロジックはバイト単位でそのまま移動しただけで、呼び出し側（`const valid = await verifyGitHubSignature(...)`）も変更なし。ユーザー/システム観測可能なランタイム変更はない。

## 変更ファイル

| ファイル | 種別 | 内容 |
|---|---|---|
| `worker/src/signature.ts` | 新規 | `verifyGitHubSignature` を verbatim 抽出＋export。trust boundary を説明する先頭コメント追加 |
| `worker/src/index.ts` | 変更 | inline 定義を削除し `import { verifyGitHubSignature } from "./signature.js";` に差し替え |
| `worker/test/signature.test.ts` | 新規 | `tsx --test` 純 unit test。期待署名は `node:crypto` の `createHmac` で独立生成（被テスト関数を使わない oracle） |

## テスト内容

- 正しい署名（同一 secret＋同一 body）→ `true`
- 本文改竄（body A で署名し body B で検証）→ `false`
- 別 secret で検証 → `false`
- 署名フォーマット不一致（空文字 / `sha256=` prefix 無し / 長さ違いの hex）→ すべて `false`

## 確認

- `npm test`（`tsx --test test/*.test.ts && vitest run`）全 pass。
  - tsx phase: **53 pass / 0 fail**（既存 47 ＋ 新規 6）
  - vitest phase: **25 pass / 0 fail**
  - 合計 **78 pass**（既存 72 ＋ 新規 6）
- `npx tsc --noEmit`: 抽出した `signature.ts` と `index.ts` の import 差し替えは型エラーなし。`src/agent.ts` の既存エラー2件（MCP SDK の型重複・本 PR と無関係）は変更前から存在し、本変更では増減なし。