### PR TITLE
fix(worker): dedupe MCP SDK + fix agent.ts type errors, add CI tsc gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,10 @@ jobs:
       - name: mcp-server client migration tests
         run: node --test test/*.test.mjs
         working-directory: mcp-server
-      - name: worker install + dry-run deploy + OAuth device-flow tests
+      - name: worker install + typecheck + dry-run deploy + OAuth device-flow tests
         run: |
           npm ci
+          npm run typecheck
           npx wrangler deploy --dry-run --outdir dist
           npm test
         working-directory: worker

--- a/worker/package-lock.json
+++ b/worker/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@github-webhook-mcp/worker",
       "version": "0.0.1",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.0.0",
+        "@modelcontextprotocol/sdk": "1.26.0",
         "agents": "^0.8.0",
         "zod": "^4.0.0"
       },
@@ -1998,9 +1998,9 @@
       "license": "MIT"
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.27.1",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.27.1.tgz",
-      "integrity": "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==",
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.26.0.tgz",
+      "integrity": "sha512-Y5RmPncpiDtTXDbLKswIJzTqu2hyBKxTNsgKqKclDbhIgg1wgtf1fRuvxgTnRfcnxtvvgbIEcqUOzZrJ6iSReg==",
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.19.9",
@@ -2651,46 +2651,6 @@
         },
         "viem": {
           "optional": true
-        }
-      }
-    },
-    "node_modules/agents/node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.26.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.26.0.tgz",
-      "integrity": "sha512-Y5RmPncpiDtTXDbLKswIJzTqu2hyBKxTNsgKqKclDbhIgg1wgtf1fRuvxgTnRfcnxtvvgbIEcqUOzZrJ6iSReg==",
-      "license": "MIT",
-      "dependencies": {
-        "@hono/node-server": "^1.19.9",
-        "ajv": "^8.17.1",
-        "ajv-formats": "^3.0.1",
-        "content-type": "^1.0.5",
-        "cors": "^2.8.5",
-        "cross-spawn": "^7.0.5",
-        "eventsource": "^3.0.2",
-        "eventsource-parser": "^3.0.0",
-        "express": "^5.2.1",
-        "express-rate-limit": "^8.2.1",
-        "hono": "^4.11.4",
-        "jose": "^6.1.3",
-        "json-schema-typed": "^8.0.2",
-        "pkce-challenge": "^5.0.0",
-        "raw-body": "^3.0.0",
-        "zod": "^3.25 || ^4.0",
-        "zod-to-json-schema": "^3.25.1"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@cfworker/json-schema": "^4.1.1",
-        "zod": "^3.25 || ^4.0"
-      },
-      "peerDependenciesMeta": {
-        "@cfworker/json-schema": {
-          "optional": true
-        },
-        "zod": {
-          "optional": false
         }
       }
     },

--- a/worker/package.json
+++ b/worker/package.json
@@ -6,10 +6,11 @@
   "scripts": {
     "dev": "wrangler dev",
     "deploy": "wrangler deploy",
+    "typecheck": "tsc --noEmit",
     "test": "tsx --test test/*.test.ts && vitest run --config vitest.workers.config.ts"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.0.0",
+    "@modelcontextprotocol/sdk": "1.26.0",
     "agents": "^0.8.0",
     "zod": "^4.0.0"
   },
@@ -22,9 +23,10 @@
     "wrangler": "^4.0.0"
   },
   "comments": {
-    "overrides": "Pin @cloudflare/workers-types across the tree to the version the worker code is written against; the vitest-pool-workers toolchain otherwise pulls a newer one whose stricter binding types can break existing src types (types-only; runtime unaffected)."
+    "overrides": "Pin @cloudflare/workers-types across the tree to the version the worker code is written against; the vitest-pool-workers toolchain otherwise pulls a newer one whose stricter binding types can break existing src types (types-only; runtime unaffected). Pin @modelcontextprotocol/sdk to 1.26.0 so the tree holds a single copy: agents@0.8.2 nests its own 1.26.0, and a separate worker-direct copy made McpServer's private _serverInfo incompatible at the type level (types-only; 1.26/1.27 are runtime-compatible)."
   },
   "overrides": {
-    "@cloudflare/workers-types": "$@cloudflare/workers-types"
+    "@cloudflare/workers-types": "$@cloudflare/workers-types",
+    "@modelcontextprotocol/sdk": "$@modelcontextprotocol/sdk"
   }
 }

--- a/worker/src/agent.ts
+++ b/worker/src/agent.ts
@@ -21,12 +21,12 @@ interface Env {
 }
 
 /** Tenant context passed via props when creating per-tenant instances */
-export interface TenantProps {
+export type TenantProps = {
   account_id?: number;
   account_login?: string;
   /** All account IDs (user + orgs) whose stores this session can read */
   accessible_account_ids?: number[];
-}
+};
 
 export class WebhookMcpAgent extends McpAgent<Env, unknown, TenantProps> {
   server = new McpServer({


### PR DESCRIPTION
## 概要

worker の型チェック (`tsc --noEmit`) が CI で走っておらず, `agent.ts` に型エラー 2 件が静かに蓄積していた (PR #237 のセルフレビュー中に発見). 2 件を修正し, 再発防止に tsc 型ゲートを CI に追加する.

影響スコープ = worker (型/ビルド健全性のみ, runtime 挙動・MCP ツール意味論は不変).

## 変更内容

- **(1) MCP SDK の dedupe (TS2416 解消)**: `@modelcontextprotocol/sdk` が依存ツリーに 2 コピー (worker 直下 1.27.1 / `agents@0.8.2` nested 1.26.0) 存在し, 別コピーのため `McpServer` の private フィールド `_serverInfo` が非互換になっていた. 版差ではなく「2 コピーある」こと自体が原因. `worker/package.json` の `overrides` に `@modelcontextprotocol/sdk` を追加し, `agents@0.8.2` が要求する 1.26.0 (より制約の強い consumer, 安全側) に単一版へ寄せた. 既存の `@cloudflare/workers-types` override と同じ self-reference 形式を踏襲.
- **(2) `TenantProps` の type 化 (TS2344 解消)**: TypeScript の `interface` は暗黙の index signature を持たず `Record<string, unknown>` 制約に不適合だったため, `interface TenantProps` を `type TenantProps =` に変更.
- **(3) CI 型ゲート追加**: worker に `typecheck` script (`tsc --noEmit`) を追加し, `.github/workflows/ci.yml` の worker job で `npm ci` 直後に `npm run typecheck` を実行. 型エラーで CI が fail するゲートにした.

## 順序遵守

(1) dedupe + (2) type 化を先に適用し `tsc --noEmit` を完全クリア (エラーゼロ) にしてから (3) のゲートを有効化した. ゲートを先に入れると既存エラーで CI が赤くなるため.

## 検証

- `cd worker && npx tsc --noEmit` → エラーゼロ (exit 0).
- dedupe 確認: ディスク上の `@modelcontextprotocol/sdk` は単一コピー (1.26.0) のみ, nested コピーは消失. `npm ls` も `agents` 側が `1.26.0 deduped` 表示.
- ゲート動作確認: 故意に型エラーを 1 件入れると `npm run typecheck` が exit 2 (CI 赤), revert で exit 0 に復帰.
- 全テスト green: tsx 54 件 + vitest (workers) 35 件, fail 0.
- Workers build (`wrangler deploy --dry-run`) green.

## 対象ファイル

- `worker/package.json` (overrides + typecheck script)
- `worker/package-lock.json` (dedupe 反映)
- `worker/src/agent.ts`
- `.github/workflows/ci.yml`

Closes #238
